### PR TITLE
[fix] Vercelのpreview画面でAPI通信を試みるとCORS設定で弾かれる不具合を修正 #23

### DIFF
--- a/backend/config/initializers/cors.rb
+++ b/backend/config/initializers/cors.rb
@@ -18,7 +18,7 @@
 # 特定のフロントエンドからのリクエストを明示的に許可
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins 'http://localhost:5173', 'https://www.topcore.me', 'https://topcore.me' # React側のURL
+    origins 'http://localhost:5173', 'https://www.topcore.me', 'https://topcore.me', 'https://topcore-me-git-feature-search-album-api2-due-it-yous-projects.vercel.app/' # React側のURL
     resource '*',
       headers: :any,
       methods: %i[get post put patch delete options head],


### PR DESCRIPTION
## 概要
Vercelのpreview画面でAPI通信を試みるとCORS設定で弾かれる不具合を修正しました。

## 解決法
preview画面のURLを`cors.rb`に追加し、preview画面からのリクエストを許可するように変更