### PR TITLE
[fix] TailwindCSSのclassNameの値を動的に変更しようとしていたことで本番環境でCSSが適用されない不具合を修正

### DIFF
--- a/frontend/src/components/ui/color_palette/Color.jsx
+++ b/frontend/src/components/ui/color_palette/Color.jsx
@@ -5,7 +5,8 @@ export default function Color({ className, color, setColor }) {
   return (
     <button
       onClick={onColorClick}
-      className={`h-8 w-8 rounded-full ${className} bg-[${color}] hover:opacity-75`}
+      className="h-8 w-8 rounded-full hover:opacity-75 border border-gray-600"
+      style={{ background: color }}
     ></button>
   );
 }

--- a/frontend/src/components/ui/color_palette/ColorPalette.jsx
+++ b/frontend/src/components/ui/color_palette/ColorPalette.jsx
@@ -4,7 +4,7 @@ export default function ColorPalette({ color, setColor }) {
   return (
     <div className="mt-8 flex h-2/3 w-3/5 justify-center rounded-2xl bg-[#151A1E]">
       <div className="my-4 grid grid-cols-1 gap-1">
-        <Color color={'#121212'} className={'border border-gray-600'} setColor={setColor} />
+        <Color color={'#121212'} setColor={setColor} />
         <Color color={'#3E7CB6'} setColor={setColor} />
         <Color color={'#72A7D3'} setColor={setColor} />
         <Color color={'#79A00E'} setColor={setColor} />


### PR DESCRIPTION
## 概要
TailwindCSSのclassNameの値を動的に変更しようとしていたことで本番環境でCSSが適用されない不具合を修正

## 原因
`h-8 w-8 rounded-full ${className} bg-[${color}] hover:opacity-75`のように動的に`className`の値を変更しようとしていましたが、 tailwindCSSは呼び出し元でしか定義されないクラスを検出できませんので、問題が発生していました。

## 修正内容
代わりに、Reactのstyle属性を用いることで修正しました。