### PR TITLE
[add] グリッドを作成する時に表示するユーザー名と画像の設定のモーダルを追加 #11

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@radix-ui/react-dialog": "^1.1.14",
+        "@radix-ui/react-slider": "^1.3.5",
         "@radix-ui/react-slot": "^1.2.3",
         "@tailwindcss/vite": "^4.1.10",
         "axios": "^1.10.0",
@@ -1177,11 +1178,43 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/@radix-ui/number": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+      "integrity": "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
       "integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==",
       "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-collection": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+      "integrity": "sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
@@ -1244,6 +1277,21 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+      "integrity": "sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }
@@ -1404,6 +1452,39 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-slider": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.5.tgz",
+      "integrity": "sha512-rkfe2pU2NBAYfGaxa3Mqosi7VZEWX5CxKaanRv0vZd4Zhl9fvQrg0VM93dv3xGLGfrHuoTRF3JXH8nb9g+B3fw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.1.1",
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1",
+        "@radix-ui/react-use-previous": "1.1.1",
+        "@radix-ui/react-use-size": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
@@ -1497,6 +1578,39 @@
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
       "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
       "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-previous": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.1.tgz",
+      "integrity": "sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+      "integrity": "sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,6 +21,7 @@
         "lucide-react": "^0.514.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-easy-crop": "^5.4.2",
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "^4.1.10"
       },
@@ -5125,6 +5126,12 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true
     },
+    "node_modules/normalize-wheel": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-wheel/-/normalize-wheel-1.0.1.tgz",
+      "integrity": "sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/nwsapi": {
       "version": "2.2.20",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.20.tgz",
@@ -5655,6 +5662,20 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-easy-crop": {
+      "version": "5.4.2",
+      "resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-5.4.2.tgz",
+      "integrity": "sha512-V+GQUTkNWD8gK0mbZQfwTvcDxyCB4GS0cM36is8dAcvnsHY7DMEDP2D5IqHju55TOiCHwElJPVOYDgiu8BEiHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "normalize-wheel": "^1.0.1",
+        "tslib": "^2.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.4.0",
+        "react-dom": ">=16.4.0"
       }
     },
     "node_modules/react-is": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@radix-ui/react-dialog": "^1.1.14",
         "@radix-ui/react-slot": "^1.2.3",
         "@tailwindcss/vite": "^4.1.10",
         "axios": "^1.10.0",
@@ -1175,6 +1176,12 @@
         "url": "https://opencollective.com/unts"
       }
     },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.2.tgz",
+      "integrity": "sha512-XnbHrrprsNqZKQhStrSwgRUQzoCI1glLzdw79xiZPoofhGICeZRSQ3dIxAKH1gb3OHfNf4d6f+vAv3kil2eggA==",
+      "license": "MIT"
+    },
     "node_modules/@radix-ui/react-compose-refs": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
@@ -1189,6 +1196,213 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+      "integrity": "sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.14.tgz",
+      "integrity": "sha512-+CpweKjqpzTmwRwcYECQcNYbI8V9VSQt0SNFKeEBLgfucbsLssU6Ppq7wUdNXEGb573bMjFhVjKVll8rmV6zMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.10",
+        "@radix-ui/react-focus-guards": "1.1.2",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.10.tgz",
+      "integrity": "sha512-IM1zzRV4W3HtVgftdQiiOmA0AdJlCtMLe00FXaHwgt3rAnNsIyDqshvkIW3hj/iu5hu8ERP7KIYki6NkqDxAwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-escape-keydown": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.2.tgz",
+      "integrity": "sha512-fyjAACV62oPV925xFCrH8DR5xWhg9KYtJT4s3u54jxp+L/hbpTY2kIeEFFbFe+a/HCE94zGQMZLIpVTPVZDhaA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+      "integrity": "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+      "integrity": "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-portal": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+      "integrity": "sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.4.tgz",
+      "integrity": "sha512-ueDqRbdc4/bkaQT3GIpLQssRlFgWaL/U2z/S31qRwwLWoxHLgry3SIfCwhxeQNbirEUXFa+lq3RL3oBYXtcmIA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+      "integrity": "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slot": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
@@ -1197,6 +1411,91 @@
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.2"
       },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+      "integrity": "sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+      "integrity": "sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+      "integrity": "sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+      "integrity": "sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+      "integrity": "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==",
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
@@ -1887,7 +2186,7 @@
       "version": "19.1.6",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.6.tgz",
       "integrity": "sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==",
-      "dev": true,
+      "devOptional": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -2106,6 +2405,18 @@
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
+    },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/aria-query": {
       "version": "5.3.0",
@@ -2775,6 +3086,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
     },
     "node_modules/doctrine": {
       "version": "2.1.0",
@@ -3541,6 +3858,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/get-proto": {
@@ -5346,6 +5672,75 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.1.tgz",
+      "integrity": "sha512-HpMh8+oahmIdOuS5aFKKY6Pyog+FNaZV/XyJOq7b4YFwsFHe5yYfdbIalI4k3vU2nSDql7YskmUseHsRrJqIPA==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -6244,6 +6639,49 @@
       "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/vite": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "lucide-react": "^0.514.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-easy-crop": "^5.4.2",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.10"
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-dialog": "^1.1.14",
+    "@radix-ui/react-slider": "^1.3.5",
     "@radix-ui/react-slot": "^1.2.3",
     "@tailwindcss/vite": "^4.1.10",
     "axios": "^1.10.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@radix-ui/react-dialog": "^1.1.14",
     "@radix-ui/react-slot": "^1.2.3",
     "@tailwindcss/vite": "^4.1.10",
     "axios": "^1.10.0",

--- a/frontend/src/components/ui/album_grid_editor/AlbumGridEditor.jsx
+++ b/frontend/src/components/ui/album_grid_editor/AlbumGridEditor.jsx
@@ -30,16 +30,18 @@ export default function AlbumGridEditor({ assignedAlbums, color, setColor }) {
                 </DialogTrigger>
                 <DialogContent className="border border-[#646464] bg-[#151A1E] p-12 text-white sm:max-w-[425px]">
                   <DialogHeader>
-                    <DialogTitle>ユーザー名とアイコンの設定</DialogTitle>
-                    <DialogDescription>※アイコンの設定は任意です</DialogDescription>
+                    <DialogTitle>アイコンの設定（任意）</DialogTitle>
                   </DialogHeader>
                   <div>
                     <Uploader />
                   </div>
+                  <DialogHeader className="mt-4">
+                    <DialogTitle>表示するユーザ名の設定（必須）</DialogTitle>
+                  </DialogHeader>
                   <div>
                     <Input />
                   </div>
-                  <DialogFooter>
+                  <DialogFooter className="mt-4">
                     <DialogClose asChild>
                       <Button className="border border-gray-400 hover:bg-gray-800">
                         キャンセル

--- a/frontend/src/components/ui/album_grid_editor/AlbumGridEditor.jsx
+++ b/frontend/src/components/ui/album_grid_editor/AlbumGridEditor.jsx
@@ -1,5 +1,15 @@
 import ColorPalette from '../color_palette/ColorPalette';
 import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
 import DropAlbumGrid from './DropAlbumGrid';
 
 export default function AlbumGridEditor({ assignedAlbums, color, setColor }) {
@@ -9,9 +19,33 @@ export default function AlbumGridEditor({ assignedAlbums, color, setColor }) {
         <div className="h-full p-12">
           <DropAlbumGrid assignedAlbums={assignedAlbums} />
           <div className="mt-4 text-right">
-            <Button className="bg-[#20C997] font-semibold text-white hover:bg-[#1DB954]">
-              リンクを生成
-            </Button>
+            <Dialog>
+              <form>
+                <DialogTrigger asChild>
+                  <Button className="bg-[#20C997] font-semibold text-white hover:bg-[#1DB954]">
+                    リンクを生成
+                  </Button>
+                </DialogTrigger>
+                <DialogContent className="border border-[#646464] bg-[#151A1E] p-12 text-white sm:max-w-[425px]">
+                  <DialogHeader>
+                    <DialogTitle>ユーザー名とアイコンの設定</DialogTitle>
+                    <DialogDescription>
+                      ※アイコンの設定は任意です
+                    </DialogDescription>
+                  </DialogHeader>
+                  <div className="grid gap-4">
+                    <div className="grid gap-3"></div>
+                    <div className="grid gap-3"></div>
+                  </div>
+                  <DialogFooter>
+                    <DialogClose asChild>
+                      <Button variant="outline">Cancel</Button>
+                    </DialogClose>
+                    <Button type="submit">Save changes</Button>
+                  </DialogFooter>
+                </DialogContent>
+              </form>
+            </Dialog>
           </div>
         </div>
         <div className="h-full w-1/4">

--- a/frontend/src/components/ui/album_grid_editor/AlbumGridEditor.jsx
+++ b/frontend/src/components/ui/album_grid_editor/AlbumGridEditor.jsx
@@ -11,6 +11,7 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog';
 import DropAlbumGrid from './DropAlbumGrid';
+import { Input } from '../input';
 
 export default function AlbumGridEditor({ assignedAlbums, color, setColor }) {
   return (
@@ -29,19 +30,18 @@ export default function AlbumGridEditor({ assignedAlbums, color, setColor }) {
                 <DialogContent className="border border-[#646464] bg-[#151A1E] p-12 text-white sm:max-w-[425px]">
                   <DialogHeader>
                     <DialogTitle>ユーザー名とアイコンの設定</DialogTitle>
-                    <DialogDescription>
-                      ※アイコンの設定は任意です
-                    </DialogDescription>
+                    <DialogDescription>※アイコンの設定は任意です</DialogDescription>
                   </DialogHeader>
-                  <div className="grid gap-4">
-                    <div className="grid gap-3"></div>
-                    <div className="grid gap-3"></div>
+                  <div>
+                    <Input />
                   </div>
                   <DialogFooter>
                     <DialogClose asChild>
-                      <Button variant="outline">Cancel</Button>
+                      <Button className="hover:bg-gray-800 border border-gray-400">キャンセル</Button>
                     </DialogClose>
-                    <Button type="submit">Save changes</Button>
+                    <Button type="submit" className="bg-[#20C997] font-bold hover:bg-[#1DB954]">
+                      完了
+                    </Button>
                   </DialogFooter>
                 </DialogContent>
               </form>

--- a/frontend/src/components/ui/album_grid_editor/AlbumGridEditor.jsx
+++ b/frontend/src/components/ui/album_grid_editor/AlbumGridEditor.jsx
@@ -1,3 +1,4 @@
+import Uploader from '../upload_image/Uploader';
 import ColorPalette from '../color_palette/ColorPalette';
 import { Button } from '@/components/ui/button';
 import {
@@ -33,11 +34,16 @@ export default function AlbumGridEditor({ assignedAlbums, color, setColor }) {
                     <DialogDescription>※アイコンの設定は任意です</DialogDescription>
                   </DialogHeader>
                   <div>
+                    <Uploader />
+                  </div>
+                  <div>
                     <Input />
                   </div>
                   <DialogFooter>
                     <DialogClose asChild>
-                      <Button className="hover:bg-gray-800 border border-gray-400">キャンセル</Button>
+                      <Button className="border border-gray-400 hover:bg-gray-800">
+                        キャンセル
+                      </Button>
                     </DialogClose>
                     <Button type="submit" className="bg-[#20C997] font-bold hover:bg-[#1DB954]">
                       完了

--- a/frontend/src/components/ui/dialog.jsx
+++ b/frontend/src/components/ui/dialog.jsx
@@ -1,0 +1,135 @@
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { XIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function Dialog({
+  ...props
+}) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
+
+function DialogTrigger({
+  ...props
+}) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
+
+function DialogPortal({
+  ...props
+}) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
+
+function DialogClose({
+  ...props
+}) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props} />
+  );
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}) {
+  return (
+    <DialogPortal data-slot="dialog-portal">
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}>
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            className="ring-offset-background focus:ring-ring data-[state=open]:bg-accent data-[state=open]:text-muted-foreground absolute top-4 right-4 rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4">
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  );
+}
+
+function DialogHeader({
+  className,
+  ...props
+}) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props} />
+  );
+}
+
+function DialogFooter({
+  className,
+  ...props
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn("flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)}
+      {...props} />
+  );
+}
+
+function DialogTitle({
+  className,
+  ...props
+}) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn("text-lg leading-none font-semibold", className)}
+      {...props} />
+  );
+}
+
+function DialogDescription({
+  className,
+  ...props
+}) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props} />
+  );
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/frontend/src/components/ui/slider.jsx
+++ b/frontend/src/components/ui/slider.jsx
@@ -1,0 +1,54 @@
+import * as React from "react"
+import * as SliderPrimitive from "@radix-ui/react-slider"
+
+import { cn } from "@/lib/utils"
+
+function Slider({
+  className,
+  defaultValue,
+  value,
+  min = 0,
+  max = 100,
+  ...props
+}) {
+  const _values = React.useMemo(() =>
+    Array.isArray(value)
+      ? value
+      : Array.isArray(defaultValue)
+        ? defaultValue
+        : [min, max], [value, defaultValue, min, max])
+
+  return (
+    <SliderPrimitive.Root
+      data-slot="slider"
+      defaultValue={defaultValue}
+      value={value}
+      min={min}
+      max={max}
+      className={cn(
+        "relative flex w-full touch-none items-center select-none data-[disabled]:opacity-50 data-[orientation=vertical]:h-full data-[orientation=vertical]:min-h-44 data-[orientation=vertical]:w-auto data-[orientation=vertical]:flex-col",
+        className
+      )}
+      {...props}>
+      <SliderPrimitive.Track
+        data-slot="slider-track"
+        className={cn(
+          "bg-muted relative grow overflow-hidden rounded-full data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5"
+        )}>
+        <SliderPrimitive.Range
+          data-slot="slider-range"
+          className={cn(
+            "bg-primary absolute data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full"
+          )} />
+      </SliderPrimitive.Track>
+      {Array.from({ length: _values.length }, (_, index) => (
+        <SliderPrimitive.Thumb
+          data-slot="slider-thumb"
+          key={index}
+          className="border-primary bg-background ring-ring/50 block size-4 shrink-0 rounded-full border shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50" />
+      ))}
+    </SliderPrimitive.Root>
+  );
+}
+
+export { Slider }

--- a/frontend/src/components/ui/slider.jsx
+++ b/frontend/src/components/ui/slider.jsx
@@ -33,19 +33,19 @@ function Slider({
       <SliderPrimitive.Track
         data-slot="slider-track"
         className={cn(
-          "bg-muted relative grow overflow-hidden rounded-full data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5"
+          "bg-gray-300 relative grow overflow-hidden rounded-full data-[orientation=horizontal]:h-1.5 data-[orientation=horizontal]:w-full data-[orientation=vertical]:h-full data-[orientation=vertical]:w-1.5"
         )}>
         <SliderPrimitive.Range
           data-slot="slider-range"
           className={cn(
-            "bg-primary absolute data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full"
+            "bg-blue-400 absolute data-[orientation=horizontal]:h-full data-[orientation=vertical]:w-full"
           )} />
       </SliderPrimitive.Track>
       {Array.from({ length: _values.length }, (_, index) => (
         <SliderPrimitive.Thumb
           data-slot="slider-thumb"
           key={index}
-          className="border-primary bg-background ring-ring/50 block size-4 shrink-0 rounded-full border shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50" />
+          className="bg-white border-primary bg-background ring-ring/50 block size-4 shrink-0 rounded-full border shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden disabled:pointer-events-none disabled:opacity-50" />
       ))}
     </SliderPrimitive.Root>
   );

--- a/frontend/src/components/ui/upload_image/CropperModal.jsx
+++ b/frontend/src/components/ui/upload_image/CropperModal.jsx
@@ -26,6 +26,7 @@ export default function CropperModal({
           <Cropper
             image={imgSrc}
             crop={crop}
+            cropShape="round"
             zoom={zoom}
             minZoom={minZoom}
             maxZoom={minZoom + 3}

--- a/frontend/src/components/ui/upload_image/CropperModal.jsx
+++ b/frontend/src/components/ui/upload_image/CropperModal.jsx
@@ -1,0 +1,87 @@
+import React from 'react';
+import Cropper from 'react-easy-crop';
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Slider } from '@/components/ui/slider';
+import { ASPECT_RATIO, CROP_WIDTH } from './Uploader';
+
+export default function CropperModal({
+  crop,
+  setCrop,
+  zoom,
+  setZoom,
+  onCropComplete,
+  open,
+  onClose,
+  imgSrc,
+  showCroppedImage,
+  onMediaLoaded,
+  minZoom,
+}) {
+  return (
+    <Dialog open={open} onOpenChange={onClose}>
+      <DialogContent className="w-[420px] h-[500px] flex flex-col justify-center rounded-lg p-0 overflow-hidden">
+        <div className="relative h-[400px] bg-[#f4f7fb] rounded-t-lg">
+          <Cropper
+            image={imgSrc}
+            crop={crop}
+            zoom={zoom}
+            minZoom={minZoom}
+            maxZoom={minZoom + 3}
+            aspect={ASPECT_RATIO}
+            onCropChange={setCrop}
+            onCropComplete={onCropComplete}
+            onZoomChange={setZoom}
+            cropSize={{
+              width: CROP_WIDTH,
+              height: CROP_WIDTH / ASPECT_RATIO,
+            }}
+            classes={{
+              containerClassName: 'container',
+              cropAreaClassName: 'border-4 border-[#00A0FF]',
+              mediaClassName: 'media',
+            }}
+            onMediaLoaded={onMediaLoaded}
+            showGrid={false}
+          />
+        </div>
+
+        <div className="flex items-center mt-2 px-6 h-10">
+          <Slider
+            min={minZoom}
+            max={minZoom + 3}
+            step={0.1}
+            value={[zoom]}
+            onValueChange={(value) => {
+              if (typeof value[0] === 'number') {
+                setZoom(value[0]);
+              }
+            }}
+            className="w-full text-[#00A0FF]"
+          />
+        </div>
+
+        <div className="flex justify-between items-center px-10 mt-3 mb-2">
+          <Button
+            variant="secondary"
+            className="bg-gray-500 text-white hover:bg-gray-600"
+            onClick={onClose}
+          >
+            Close
+          </Button>
+          <Button
+            className="bg-[#00A0FF] text-white hover:bg-[#0088dd]"
+            onClick={() => {
+              onClose();
+              showCroppedImage();
+            }}
+          >
+            OK
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+

--- a/frontend/src/components/ui/upload_image/CropperModal.jsx
+++ b/frontend/src/components/ui/upload_image/CropperModal.jsx
@@ -59,8 +59,13 @@ export default function CropperModal({
                 setZoom(value[0]);
               }
             }}
-            className="w-full text-[#00A0FF]"
-          />
+            className="relative flex w-full touch-none items-center select-none"
+          >
+            <Slider.Track className="relative h-2 w-full grow overflow-hidden rounded-full bg-gray-700">
+              <Slider.Range className="absolute h-full bg-[#00A0FF]" />
+            </Slider.Track>
+            <Slider.Thumb className="block h-5 w-5 rounded-full border-2 border-white bg-[#00A0FF] shadow transition-colors hover:bg-[#0088dd] focus:ring-2 focus:ring-[#00A0FF] focus:outline-none" />
+          </Slider>
         </div>
 
         <div className="mt-3 mb-2 flex items-center justify-between px-10">

--- a/frontend/src/components/ui/upload_image/CropperModal.jsx
+++ b/frontend/src/components/ui/upload_image/CropperModal.jsx
@@ -20,7 +20,7 @@ export default function CropperModal({
 }) {
   return (
     <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="flex h-[500px] w-[420px] flex-col justify-center overflow-hidden rounded-lg p-0">
+      <DialogContent className="flex h-[600px] w-[520px] flex-col justify-center overflow-hidden rounded-lg border border-gray-700 bg-black p-8">
         <DialogTitle className="sr-only">画像の切り取り</DialogTitle>
         <div className="relative h-[400px] rounded-t-lg bg-[#f4f7fb]">
           <Cropper

--- a/frontend/src/components/ui/upload_image/CropperModal.jsx
+++ b/frontend/src/components/ui/upload_image/CropperModal.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Cropper from 'react-easy-crop';
-import { Dialog, DialogContent } from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Slider } from '@/components/ui/slider';
 import { ASPECT_RATIO, CROP_WIDTH } from './Uploader';
@@ -20,8 +20,9 @@ export default function CropperModal({
 }) {
   return (
     <Dialog open={open} onOpenChange={onClose}>
-      <DialogContent className="w-[420px] h-[500px] flex flex-col justify-center rounded-lg p-0 overflow-hidden">
-        <div className="relative h-[400px] bg-[#f4f7fb] rounded-t-lg">
+      <DialogContent className="flex h-[500px] w-[420px] flex-col justify-center overflow-hidden rounded-lg p-0">
+        <DialogTitle className="sr-only">画像の切り取り</DialogTitle>
+        <div className="relative h-[400px] rounded-t-lg bg-[#f4f7fb]">
           <Cropper
             image={imgSrc}
             crop={crop}
@@ -46,7 +47,7 @@ export default function CropperModal({
           />
         </div>
 
-        <div className="flex items-center mt-2 px-6 h-10">
+        <div className="mt-2 flex h-10 items-center px-6">
           <Slider
             min={minZoom}
             max={minZoom + 3}
@@ -61,7 +62,7 @@ export default function CropperModal({
           />
         </div>
 
-        <div className="flex justify-between items-center px-10 mt-3 mb-2">
+        <div className="mt-3 mb-2 flex items-center justify-between px-10">
           <Button
             variant="secondary"
             className="bg-gray-500 text-white hover:bg-gray-600"
@@ -83,5 +84,3 @@ export default function CropperModal({
     </Dialog>
   );
 }
-
-

--- a/frontend/src/components/ui/upload_image/Uploader.jsx
+++ b/frontend/src/components/ui/upload_image/Uploader.jsx
@@ -3,6 +3,8 @@ import { ASPECT_RATIO, CROP_WIDTH } from './constants';
 import CropperModal from './CropperModal';
 import getCroppedImg from '@/js/getCroppedImg';
 import { Button } from '@/components/ui/button';
+export const ASPECT_RATIO = 6 / 1;
+export const CROP_WIDTH = 400;
 
 const Uploader = () => {
   const [isOpen, setIsOpen] = useState(false);

--- a/frontend/src/components/ui/upload_image/Uploader.jsx
+++ b/frontend/src/components/ui/upload_image/Uploader.jsx
@@ -56,47 +56,49 @@ const Uploader = () => {
   }, [croppedAreaPixels, imgSrc]);
 
   return (
-    <div className="mx-auto mt-8 flex w-full max-w-xl flex-col items-center space-y-8">
-      {/* アップロードした画像が表示される場所 */}
-      <div
-        className="relative overflow-hidden rounded border border-gray-400 bg-gray-100"
-        style={{
-          width: `${CROP_WIDTH}px`,
-          height: `${CROP_WIDTH / ASPECT_RATIO}px`,
-          borderRadius: '50%',
-        }}
-      >
-        {croppedImgSrc ? (
-          <img src={croppedImgSrc} alt="Cropped" className="h-full w-full object-contain" />
-        ) : (
-          <div className="flex h-full w-full items-center justify-center bg-gray-400"></div>
-        )}
-      </div>
+    <div className="flex">
+      <div className="mx-auto mt-4 flex w-full max-w-xl items-center justify-center space-y-4">
+        {/* アップロードした画像が表示される場所 */}
+        <div
+          className="mt-4 mr-4 relative overflow-hidden rounded border border-gray-400 bg-gray-100"
+          style={{
+            width: `${CROP_WIDTH}px`,
+            height: `${CROP_WIDTH / ASPECT_RATIO}px`,
+            borderRadius: '50%',
+          }}
+        >
+          {croppedImgSrc ? (
+            <img src={croppedImgSrc} alt="Cropped" className="h-full w-full object-contain" />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center bg-gray-400"></div>
+          )}
+        </div>
 
-      {/* アップローダー */}
-      <div>
-        <label className="inline-flex items-center space-x-2">
-          <Button asChild className="ml-2 bg-blue-500">
-            <span>画像をアップロード</span>
-          </Button>
-          <input type="file" accept="image/*" onChange={onFileChange} className="hidden" />
-        </label>
-      </div>
+        {/* アップローダー */}
+        <div>
+          <label className="inline-flex items-center space-x-2">
+            <Button asChild className="ml-2 bg-blue-500">
+              <span>画像をアップロード</span>
+            </Button>
+            <input type="file" accept="image/*" onChange={onFileChange} className="hidden" />
+          </label>
+        </div>
 
-      {/* 実際にユーザーがクロップを行う時のモーダル */}
-      <CropperModal
-        crop={crop}
-        setCrop={setCrop}
-        zoom={zoom}
-        setZoom={setZoom}
-        onCropComplete={onCropComplete}
-        open={isOpen}
-        onClose={() => setIsOpen(false)}
-        imgSrc={imgSrc}
-        showCroppedImage={showCroppedImage}
-        onMediaLoaded={onMediaLoaded}
-        minZoom={minZoom}
-      />
+        {/* 実際にユーザーがクロップを行う時のモーダル */}
+        <CropperModal
+          crop={crop}
+          setCrop={setCrop}
+          zoom={zoom}
+          setZoom={setZoom}
+          onCropComplete={onCropComplete}
+          open={isOpen}
+          onClose={() => setIsOpen(false)}
+          imgSrc={imgSrc}
+          showCroppedImage={showCroppedImage}
+          onMediaLoaded={onMediaLoaded}
+          minZoom={minZoom}
+        />
+      </div>
     </div>
   );
 };

--- a/frontend/src/components/ui/upload_image/Uploader.jsx
+++ b/frontend/src/components/ui/upload_image/Uploader.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useCallback } from 'react';
 import { ASPECT_RATIO, CROP_WIDTH } from './constants';
 import CropperModal from './CropperModal';
-import getCroppedImg from './getCroppedImg';
+import getCroppedImg from '@/js/getCroppedImg';
 import { Button } from '@/components/ui/button';
 
 const Uploader = () => {

--- a/frontend/src/components/ui/upload_image/Uploader.jsx
+++ b/frontend/src/components/ui/upload_image/Uploader.jsx
@@ -11,7 +11,7 @@ const Uploader = () => {
   const [zoom, setZoom] = useState(1);
   const [minZoom, setMinZoom] = useState(1);
   const [crop, setCrop] = useState({ x: 0, y: 0 });
-  const [croppedAreaPixels, setCroppedAreaPixels] = useState(null);
+  const [croppedAreaPixels, setCroppedAreaPixels] = useState();
   const [croppedImgSrc, setCroppedImgSrc] = useState('');
 
   const onFileChange = useCallback(async (e) => {

--- a/frontend/src/components/ui/upload_image/Uploader.jsx
+++ b/frontend/src/components/ui/upload_image/Uploader.jsx
@@ -61,7 +61,7 @@ const Uploader = () => {
       <div>
         <label className="inline-flex items-center space-x-2">
           <Button asChild>
-            <span>ファイルをアップロード</span>
+            <span>画像をアップロード</span>
           </Button>
           <input type="file" accept="image/*" onChange={onFileChange} className="hidden" />
         </label>

--- a/frontend/src/components/ui/upload_image/Uploader.jsx
+++ b/frontend/src/components/ui/upload_image/Uploader.jsx
@@ -2,8 +2,8 @@ import React, { useState, useCallback } from 'react';
 import CropperModal from './CropperModal';
 import getCroppedImg from '@/js/getCroppedImg';
 import { Button } from '@/components/ui/button';
-export const ASPECT_RATIO = 6 / 1;
-export const CROP_WIDTH = 400;
+export const ASPECT_RATIO = 1 / 1;
+export const CROP_WIDTH = 50;
 
 const Uploader = () => {
   const [isOpen, setIsOpen] = useState(false);
@@ -73,14 +73,13 @@ const Uploader = () => {
         style={{
           width: `${CROP_WIDTH}px`,
           height: `${CROP_WIDTH / ASPECT_RATIO}px`,
+          borderRadius: '50%',
         }}
       >
         {croppedImgSrc ? (
           <img src={croppedImgSrc} alt="Cropped" className="h-full w-full object-contain" />
         ) : (
-          <div className="flex h-full w-full items-center justify-center text-gray-700">
-            The cropped image is displayed here
-          </div>
+          <div className="flex h-full w-full items-center justify-center bg-gray-400"></div>
         )}
       </div>
 

--- a/frontend/src/components/ui/upload_image/Uploader.jsx
+++ b/frontend/src/components/ui/upload_image/Uploader.jsx
@@ -1,0 +1,104 @@
+import React, { useState, useCallback } from 'react';
+import { ASPECT_RATIO, CROP_WIDTH } from './constants';
+import CropperModal from './CropperModal';
+import getCroppedImg from './getCroppedImg';
+import { Button } from '@/components/ui/button';
+
+const Uploader = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [imgSrc, setImgSrc] = useState('');
+  const [zoom, setZoom] = useState(1);
+  const [minZoom, setMinZoom] = useState(1);
+  const [crop, setCrop] = useState({ x: 0, y: 0 });
+  const [croppedAreaPixels, setCroppedAreaPixels] = useState(null);
+  const [croppedImgSrc, setCroppedImgSrc] = useState('');
+
+  const onFileChange = useCallback(async (e) => {
+    if (e.target.files && e.target.files.length > 0) {
+      const reader = new FileReader();
+      reader.addEventListener('load', () => {
+        if (reader.result) {
+          setImgSrc(reader.result.toString() || '');
+          setIsOpen(true);
+        }
+      });
+      reader.readAsDataURL(e.target.files[0]);
+    }
+  }, []);
+
+  const onMediaLoaded = useCallback((mediaSize) => {
+    const { width, height } = mediaSize;
+    const mediaAspectRadio = width / height;
+    if (mediaAspectRadio > ASPECT_RATIO) {
+      const result = CROP_WIDTH / ASPECT_RATIO / height;
+      setZoom(result);
+      setMinZoom(result);
+      return;
+    }
+    const result = CROP_WIDTH / width;
+    setZoom(result);
+    setMinZoom(result);
+  }, []);
+
+  const onCropComplete = useCallback((_, croppedAreaPixels) => {
+    setCroppedAreaPixels(croppedAreaPixels);
+  }, []);
+
+  const showCroppedImage = useCallback(async () => {
+    if (!croppedAreaPixels) return;
+    try {
+      const croppedImage = await getCroppedImg(imgSrc, croppedAreaPixels);
+      setCroppedImgSrc(croppedImage);
+    } catch (e) {
+      console.error(e);
+    }
+  }, [croppedAreaPixels, imgSrc]);
+
+  return (
+    <div className="mx-auto mt-8 flex w-full max-w-xl flex-col items-center space-y-8">
+      {/* アップローダー */}
+      <div>
+        <label className="inline-flex items-center space-x-2">
+          <Button asChild>
+            <span>ファイルをアップロード</span>
+          </Button>
+          <input type="file" accept="image/*" onChange={onFileChange} className="hidden" />
+        </label>
+      </div>
+
+      {/* アップロードした画像が表示される場所 */}
+      <div
+        className="relative overflow-hidden rounded border border-gray-400 bg-gray-100"
+        style={{
+          width: `${CROP_WIDTH}px`,
+          height: `${CROP_WIDTH / ASPECT_RATIO}px`,
+        }}
+      >
+        {croppedImgSrc ? (
+          <img src={croppedImgSrc} alt="Cropped" className="h-full w-full object-contain" />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-gray-700">
+            The cropped image is displayed here
+          </div>
+        )}
+      </div>
+
+      {/* 実際にユーザーがクロップを行う時のモーダル */}
+      <CropperModal
+        crop={crop}
+        setCrop={setCrop}
+        zoom={zoom}
+        setZoom={setZoom}
+        onCropComplete={onCropComplete}
+        open={isOpen}
+        onClose={() => setIsOpen(false)}
+        imgSrc={imgSrc}
+        showCroppedImage={showCroppedImage}
+        onMediaLoaded={onMediaLoaded}
+        minZoom={minZoom}
+      />
+    </div>
+  );
+};
+
+export default Uploader;

--- a/frontend/src/components/ui/upload_image/Uploader.jsx
+++ b/frontend/src/components/ui/upload_image/Uploader.jsx
@@ -57,16 +57,6 @@ const Uploader = () => {
 
   return (
     <div className="mx-auto mt-8 flex w-full max-w-xl flex-col items-center space-y-8">
-      {/* アップローダー */}
-      <div>
-        <label className="inline-flex items-center space-x-2">
-          <Button asChild>
-            <span>画像をアップロード</span>
-          </Button>
-          <input type="file" accept="image/*" onChange={onFileChange} className="hidden" />
-        </label>
-      </div>
-
       {/* アップロードした画像が表示される場所 */}
       <div
         className="relative overflow-hidden rounded border border-gray-400 bg-gray-100"
@@ -81,6 +71,16 @@ const Uploader = () => {
         ) : (
           <div className="flex h-full w-full items-center justify-center bg-gray-400"></div>
         )}
+      </div>
+
+      {/* アップローダー */}
+      <div>
+        <label className="inline-flex items-center space-x-2">
+          <Button asChild className="ml-2 bg-blue-500">
+            <span>画像をアップロード</span>
+          </Button>
+          <input type="file" accept="image/*" onChange={onFileChange} className="hidden" />
+        </label>
       </div>
 
       {/* 実際にユーザーがクロップを行う時のモーダル */}

--- a/frontend/src/components/ui/upload_image/Uploader.jsx
+++ b/frontend/src/components/ui/upload_image/Uploader.jsx
@@ -1,5 +1,4 @@
 import React, { useState, useCallback } from 'react';
-import { ASPECT_RATIO, CROP_WIDTH } from './constants';
 import CropperModal from './CropperModal';
 import getCroppedImg from '@/js/getCroppedImg';
 import { Button } from '@/components/ui/button';

--- a/frontend/src/js/getCroppedImg.js
+++ b/frontend/src/js/getCroppedImg.js
@@ -1,5 +1,5 @@
 export const createImage = (url) => {
-  new Promise((resolve, reject) => {
+  return new Promise((resolve, reject) => {
     const image = new Image();
     image.addEventListener('load', () => resolve(image));
     image.addEventListener('error', (error) => reject(error));

--- a/frontend/src/js/getCroppedImg.js
+++ b/frontend/src/js/getCroppedImg.js
@@ -32,7 +32,7 @@ export default async function getCroppedImg(imageSrc, pixelCrop) {
   canvas.height = pixelCrop.height;
 
   // 抽出した画像データをcanvasの左隅に貼り付け
-  createExpect.putImageData(data, 0, 0);
+  ctx.putImageData(data, 0, 0);
 
   return new Promise((resolve, reject) => {
     canvas.toBlob((file) => {

--- a/frontend/src/js/getCroppedImg.js
+++ b/frontend/src/js/getCroppedImg.js
@@ -1,0 +1,42 @@
+export const createImage = (url) => {
+  new Promise((resolve, reject) => {
+    const image = new Image();
+    image.addEventListener('load', () => resolve(image));
+    image.addEventListener('error', (error) => reject(error));
+    image.src = url;
+  });
+};
+
+// 画像トリミングを行い新しい画像URLを作成
+export default async function getCroppedImg(imageSrc, pixelCrop) {
+  const image = await createImage(imageSrc);
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+
+  if (!ctx) {
+    return '';
+  }
+
+  // canvasのサイズ指定
+  canvas.width = image.width;
+  canvas.height = image.height;
+
+  // canvas上に画像を描画
+  ctx.drawImage(image, 0, 0);
+
+  // トリミングした後の画像を抽出
+  const data = ctx.getImageData(pixelCrop.x, pixelCrop.y, pixelCrop.width, pixelCrop.height);
+
+  // canvasのサイズを切り取り後の画像サイズに更新
+  canvas.width = pixelCrop.width;
+  canvas.height = pixelCrop.height;
+
+  // 抽出した画像データをcanvasの左隅に貼り付け
+  createExpect.putImageData(data, 0, 0);
+
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((file) => {
+      if (file !== null) resolve(URL.createObjectURL(file));
+    }, 'image/jpeg');
+  });
+}


### PR DESCRIPTION
## 概要
グリッドを作成する時に表示するユーザー名と画像の設定のモーダルを追加しました。

## 変更点
・画像のクロップ加工のモーダルを提供してくれている`react-easy-crop`の導入
・shadcnのSliderの導入
・クロップ加工処理の追加
・クロップ後の画像を表示