### PR TITLE
[refactor] `profile_cards`, `profile_card_albums`, `albums`テーブルへの保存処理をトランザクション処理としてモデルに切り出す#53

### DIFF
--- a/backend/app/controllers/api/v1/profile_cards_controller.rb
+++ b/backend/app/controllers/api/v1/profile_cards_controller.rb
@@ -4,6 +4,8 @@ class Api::V1::ProfileCardsController < ApplicationController
   def create
     profile_card = ProfileCard.create_with_albums!(profile_cards_params)
     render json: { slug: profile_card.slug }
+  rescue ActiveRecord::RecordInvalid => e
+    render json: { error: e.message }
   end
 
   private

--- a/backend/app/controllers/api/v1/profile_cards_controller.rb
+++ b/backend/app/controllers/api/v1/profile_cards_controller.rb
@@ -2,27 +2,8 @@ require 'securerandom'
 
 class Api::V1::ProfileCardsController < ApplicationController
   def create
-    # profile_cards
-    slug = SecureRandom.alphanumeric(6)
-    bg_color = profile_cards_params["profile_cards"]["bg_color"]
-    display_name = profile_cards_params["profile_cards"]["display_name"]
-    grid_rows = profile_cards_params["profile_cards"]["grid_rows"]
-    grid_columns = profile_cards_params["profile_cards"]["grid_columns"]
-
-    profile_card = ProfileCard.create(
-      slug: slug,
-      bg_color: bg_color,
-      display_name: display_name,
-      grid_rows: grid_rows,
-      grid_columns: grid_columns
-    )
-
-    profile_cards_params["albums"].each_with_index do |album, index|
-      album = Album.find_or_create_by!(spotify_id: album["spotify_id"])
-
-      profile_card.profile_card_albums.create!(album: album ,position: index)
-    end
-    render json: { slug: slug }
+    profile_card = ProfileCard.create_with_albums!(profile_cards_params)
+    render json: { slug: profile_card.slug }
   end
 
   private

--- a/backend/app/models/profile_card.rb
+++ b/backend/app/models/profile_card.rb
@@ -10,19 +10,12 @@ class ProfileCard < ApplicationRecord
 
   def self.create_with_albums!(profile_cards_params)
     transaction do
-      # profile_cards
-      slug = SecureRandom.alphanumeric(6)
-      bg_color = profile_cards_params["profile_cards"]["bg_color"]
-      display_name = profile_cards_params["profile_cards"]["display_name"]
-      grid_rows = profile_cards_params["profile_cards"]["grid_rows"]
-      grid_columns = profile_cards_params["profile_cards"]["grid_columns"]
-
       profile_card = ProfileCard.create!(
-        slug: slug,
-        bg_color: bg_color,
-        display_name: display_name,
-        grid_rows: grid_rows,
-        grid_columns: grid_columns
+        slug: SecureRandom.alphanumeric(6),
+        bg_color: profile_cards_params["profile_cards"]["bg_color"],
+        display_name: profile_cards_params["profile_cards"]["display_name"],
+        grid_rows: profile_cards_params["profile_cards"]["grid_rows"],
+        grid_columns: profile_cards_params["profile_cards"]["grid_columns"]
       )
 
       profile_cards_params["albums"].each_with_index do |album, index|

--- a/backend/app/models/profile_card.rb
+++ b/backend/app/models/profile_card.rb
@@ -1,10 +1,37 @@
 class ProfileCard < ApplicationRecord
   has_many :profile_card_albums
   has_many :albums, through: :profile_card_albums
-  
+
   validates :slug, presence: true, length: { in: 1..20 }, uniqueness: true
   validates :bg_color, presence: true
   validates :display_name, presence: true, length: { in: 1..20 }
   validates :grid_rows, presence: true, numericality: { only_integer: true }
   validates :grid_columns, presence: true, numericality: { only_integer: true }
+
+  def self.create_with_albums!(profile_cards_params)
+    transaction do
+      # profile_cards
+      slug = SecureRandom.alphanumeric(6)
+      bg_color = profile_cards_params["profile_cards"]["bg_color"]
+      display_name = profile_cards_params["profile_cards"]["display_name"]
+      grid_rows = profile_cards_params["profile_cards"]["grid_rows"]
+      grid_columns = profile_cards_params["profile_cards"]["grid_columns"]
+
+      profile_card = ProfileCard.create!(
+        slug: slug,
+        bg_color: bg_color,
+        display_name: display_name,
+        grid_rows: grid_rows,
+        grid_columns: grid_columns
+      )
+
+      profile_cards_params["albums"].each_with_index do |album, index|
+        album = Album.find_or_create_by!(spotify_id: album["spotify_id"])
+
+        profile_card.profile_card_albums.create!(album: album ,position: index)
+      end
+      
+      profile_card
+    end
+  end
 end

--- a/frontend/src/components/layout/CreateGridBody.jsx
+++ b/frontend/src/components/layout/CreateGridBody.jsx
@@ -109,7 +109,11 @@ export default function CreateGridBody({ color, setColor }) {
         albums: assignedAlbums,
       },
     });
-    const slug = res.data.slug
+    if (res.data.slug) {
+      const slug = res.data.slug
+    } else {
+      const error = res.data.error
+    }
   }
   return (
     <>


### PR DESCRIPTION
## 概要
`profile_cards`, `profile_card_albums`, `albums`テーブルへの保存処理をトランザクション処理としてモデルに切り出すことで、ファットコントローラーを解消しました。

## 変更点
・`profile_cards#create`の一連の保存処理を`ProfileCard`モデルに切り出し
・一連の保存処理をトランザクション処理に変更
・トランザクションの例外発生時にエラー文をJSONレスポンスとして返すような処理を追加