### PR TITLE
全てのグリッドのマスに割り当てがない場合、「リンクを生成」ボタンが押せないように修正 #54

### DIFF
--- a/frontend/src/components/layout/CreateGridBody.jsx
+++ b/frontend/src/components/layout/CreateGridBody.jsx
@@ -13,6 +13,7 @@ import AlbumSearchCard from '../ui/album_search/AlbumSearchCard';
 import AlbumGridEditor from '../ui/album_grid_editor/AlbumGridEditor';
 
 export default function CreateGridBody({ color, setColor }) {
+  const [disabledCreateSettingButton, setDisabledCreateSettingButton] = useState(true);
   const sensors = useSensors(
     useSensor(PointerSensor),
     useSensor(KeyboardSensor, {
@@ -99,6 +100,15 @@ export default function CreateGridBody({ color, setColor }) {
       const reordered = arrayMove(assignedAlbums, oldIndex, newIndex);
       setAssignedAlbums(reordered);
     }
+
+    // グリッドの中に全てアルバムが割り当てられた時のみ、作成へ進む]ボタンを有効化
+    assignedAlbums.forEach((album) => {
+      if (album.src || album.alt || album.spotifyId) {
+        setDisabledCreateSettingButton(true);
+      } else {
+        setDisabledCreateSettingButton(false);
+      }
+    })
   }
 
   // プロフィールカードのリンク生成
@@ -140,6 +150,7 @@ export default function CreateGridBody({ color, setColor }) {
             setColor={setColor}
             onGenerateLinkButtonClick={onGenerateLinkButtonClick}
             setDisplayName={setDisplayName}
+            disabledCreateSettingButton={disabledCreateSettingButton}
           />
         </DndContext>
       </div>

--- a/frontend/src/components/layout/CreateGridBody.jsx
+++ b/frontend/src/components/layout/CreateGridBody.jsx
@@ -102,13 +102,18 @@ export default function CreateGridBody({ color, setColor }) {
     }
 
     // グリッドの中に全てアルバムが割り当てられた時のみ、作成へ進む]ボタンを有効化
+    let assignedCellCount = 0;
     assignedAlbums.forEach((album) => {
-      if (album.src || album.alt || album.spotifyId) {
-        setDisabledCreateSettingButton(true);
-      } else {
-        setDisabledCreateSettingButton(false);
+      if (album.src && album.alt && album.spotifyId) {
+        assignedCellCount++;
       }
-    })
+    });
+
+    if (assignedCellCount === (assignedAlbums.length - 1)) {
+      setDisabledCreateSettingButton(false);
+    } else {
+      setDisabledCreateSettingButton(true);
+    }
   }
 
   // プロフィールカードのリンク生成
@@ -120,9 +125,9 @@ export default function CreateGridBody({ color, setColor }) {
       },
     });
     if (res.data.slug) {
-      const slug = res.data.slug
+      const slug = res.data.slug;
     } else {
-      const error = res.data.error
+      const error = res.data.error;
     }
   }
   return (

--- a/frontend/src/components/ui/album_grid_editor/AlbumGridEditor.jsx
+++ b/frontend/src/components/ui/album_grid_editor/AlbumGridEditor.jsx
@@ -35,7 +35,7 @@ export default function AlbumGridEditor({ assignedAlbums, color, setColor, onGen
               <form>
                 <DialogTrigger asChild>
                   <Button className="bg-[#20C997] font-semibold text-white hover:bg-[#1DB954]">
-                    リンクを生成
+                    作成へ進む
                   </Button>
                 </DialogTrigger>
                 <DialogContent className="border border-[#646464] bg-[#151A1E] p-12 text-white sm:max-w-[425px]">

--- a/frontend/src/components/ui/album_grid_editor/AlbumGridEditor.jsx
+++ b/frontend/src/components/ui/album_grid_editor/AlbumGridEditor.jsx
@@ -15,7 +15,7 @@ import {
 import DropAlbumGrid from './DropAlbumGrid';
 import { Input } from '../input';
 
-export default function AlbumGridEditor({ assignedAlbums, color, setColor, onGenerateLinkButtonClick, setDisplayName }) {
+export default function AlbumGridEditor({ assignedAlbums, color, setColor, onGenerateLinkButtonClick, setDisplayName, disabledCreateSettingButton }) {
   const [disabledGenerateLinkButton, setDisabledGenerateLinkButton] = useState(true);
   function handleDisplayNameChange(e) {
     setDisplayName(e.target.value);
@@ -34,7 +34,7 @@ export default function AlbumGridEditor({ assignedAlbums, color, setColor, onGen
             <Dialog>
               <form>
                 <DialogTrigger asChild>
-                  <Button className="bg-[#20C997] font-semibold text-white hover:bg-[#1DB954]">
+                  <Button disabled={disabledCreateSettingButton} className="bg-[#20C997] font-semibold text-white hover:bg-[#1DB954]">
                     作成へ進む
                   </Button>
                 </DialogTrigger>


### PR DESCRIPTION
## 概要
全てのグリッドのマスに割り当てがない場合、「リンクを生成」ボタンが押せないように修正

## 変更点
・`setAssignedAlbums`で割り当てられたアルバムの状態が更新されるたびに、アルバムの状態を確認して、グリッドの全てのマス（cell）にアルバムが割り当てられていれば、ボタンを有効化、それ以外はボタンを無効化にする処理を追加