### PR TITLE
[add] リンク先のプロフィールカード詳細画面の表示 #60

### DIFF
--- a/backend/app/controllers/api/v1/profile_cards_controller.rb
+++ b/backend/app/controllers/api/v1/profile_cards_controller.rb
@@ -8,6 +8,44 @@ class Api::V1::ProfileCardsController < ApplicationController
     render json: { error: e.message }
   end
 
+  def show
+    slug = params[:id]
+    profile_card = ProfileCard.find_by(slug: slug)
+    spotify_ids_arr = []
+    profile_card.albums.each do |album|
+      spotify_ids_arr << album.spotify_id
+    end
+    spotify_ids_str = spotify_ids_arr.join(',')
+
+    # アクセストークンの取得
+    response = HTTP.headers("Content-Type" => "application/x-www-form-urlencoded")
+              .post("https://accounts.spotify.com/api/token", form: {
+                grant_type: "client_credentials",
+                client_id: ENV['SPOTIFY_CLIENT_ID'],
+                client_secret: ENV['SPOTIFY_CLIENT_SECRET']
+              })
+    access_token = JSON.parse(response.body.to_s)["access_token"]
+
+    # アルバムの情報の取得
+    response = HTTP.headers("Authorization" => "Bearer #{access_token}")
+                .get("https://api.spotify.com/v1/albums?ids=#{spotify_ids_str}&market=JP")
+    assigned_albums = JSON.parse(response.body.to_s)
+    albums = assigned_albums["albums"].map do |album|
+      {
+        name: album["name"],
+        external_url: album["external_urls"]["spotify"],
+        image_url: album["images"].second["url"]
+      }
+    end
+    profile_card = {
+      bg_color: profile_card.bg_color,
+      display_name: profile_card.display_name,
+      grid_rows: profile_card.grid_rows,
+      grid_columns: profile_card.grid_columns
+    }
+    render json: { profile_card: profile_card, albums: albums }
+  end
+
   private
 
   def profile_cards_params

--- a/backend/app/controllers/api/v1/profile_cards_controller.rb
+++ b/backend/app/controllers/api/v1/profile_cards_controller.rb
@@ -30,12 +30,14 @@ class Api::V1::ProfileCardsController < ApplicationController
     response = HTTP.headers("Authorization" => "Bearer #{access_token}")
                 .get("https://api.spotify.com/v1/albums?ids=#{spotify_ids_str}&market=JP")
     assigned_albums = JSON.parse(response.body.to_s)
-    albums = assigned_albums["albums"].map do |album|
-      {
-        name: album["name"],
-        external_url: album["external_urls"]["spotify"],
-        image_url: album["images"].second["url"]
-      }
+    albums = []
+    assigned_albums["albums"].each do |album|
+      album_data = {
+                    name: album["name"],
+                    external_url: album["external_urls"]["spotify"],
+                    image_url: album["images"].second["url"]
+                  }
+      albums << album_data
     end
     profile_card = {
       bg_color: profile_card.bg_color,

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
           get :search
         end
       end
-      resources :profile_cards, only: %i[create]
+      resources :profile_cards, only: %i[create show]
     end
   end
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,6 +28,7 @@
         "react-dom": "^19.1.0",
         "react-easy-crop": "^5.4.2",
         "react-hot-toast": "^2.5.2",
+        "react-router": "^7.6.2",
         "tailwind-merge": "^3.3.1",
         "tailwindcss": "^4.1.10"
       },
@@ -3064,6 +3065,15 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
+    "node_modules/cookie": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
+      "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -5937,6 +5947,28 @@
         }
       }
     },
+    "node_modules/react-router": {
+      "version": "7.6.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.6.2.tgz",
+      "integrity": "sha512-U7Nv3y+bMimgWjhlT5CRdzHPu2/KVmqPwKUCChW8en5P3znxUqwlYFlbmyj8Rgp1SF6zs5X4+77kBVknkg6a0w==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-style-singleton": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
@@ -6181,6 +6213,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.1.tgz",
+      "integrity": "sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     "react-dom": "^19.1.0",
     "react-easy-crop": "^5.4.2",
     "react-hot-toast": "^2.5.2",
+    "react-router": "^7.6.2",
     "tailwind-merge": "^3.3.1",
     "tailwindcss": "^4.1.10"
   },

--- a/frontend/src/components/ui/profile_cards/ProfileCard.jsx
+++ b/frontend/src/components/ui/profile_cards/ProfileCard.jsx
@@ -4,9 +4,13 @@ import axios from './../../../../api/lib/apiClient';
 
 export default function ProfileCard() {
   const params = useParams();
+  const [albums, setAlbums] = useState(null);
+  const [profileCard, setProfileCard] = useState(null);
   useEffect(() => {
     async function fetchData() {
       const response = await axios.get(`/profile_cards/${params.slug}`);
+      setAlbums(response.data.albums);
+      setProfileCard(response.data.profileCard);
     }
 
     fetchData();

--- a/frontend/src/components/ui/profile_cards/ProfileCard.jsx
+++ b/frontend/src/components/ui/profile_cards/ProfileCard.jsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from 'react';
 import axios from './../../../../api/lib/apiClient';
 import Layout from '@/components/layout/Layout';
 import Header from '@/components/common/Header';
+import Album from '../album_grid_editor/Album';
 import CreateGridBody from '@/components/layout/CreateGridBody';
 
 export default function ProfileCard() {
@@ -27,18 +28,33 @@ export default function ProfileCard() {
 
   return (
     <>
-      {albums &&
-        albums.map((album, index) => {
-          return <div key={index}>{album.name}</div>;
-        })}
-      <div>{bgColor}</div>
-      <div>{displayName}</div>
-      <div>{gridColumns}</div>
-      <div>{gridRows}</div>
-      {/* <Layout color={profileCard.bgColor}>
+      <Layout color={bgColor}>
         <Header />
-        <CreateGridBody setColor={setColor} color={bgColor} />
-      </Layout> */}
+        <div className="flex min-h-screen items-center justify-center">
+          <div className="aspect-square w-110">
+            <div className="grid grid-cols-3 grid-rows-3 gap-2">
+              {albums &&
+                albums.map((album, index) => {
+                  return (
+                    <div key={index}>
+                      <a href={album.externalUrl}>
+                        <div className="aspect-square rounded-xl bg-[#0E1012]">
+                          <div>
+                            <img
+                              src={album.imageUrl}
+                              alt={album.name}
+                              className="aspect-square h-full w-full rounded-xl border border-white object-cover"
+                            />
+                          </div>
+                        </div>
+                      </a>
+                    </div>
+                  );
+                })}
+            </div>
+          </div>
+        </div>
+      </Layout>
     </>
   );
 }

--- a/frontend/src/components/ui/profile_cards/ProfileCard.jsx
+++ b/frontend/src/components/ui/profile_cards/ProfileCard.jsx
@@ -1,14 +1,16 @@
 import { useParams } from 'react-router';
-import { useState, useEffect } from 'react';
-import axios from 'axios';
+import React, { useState, useEffect } from 'react';
+import axios from './../../../../api/lib/apiClient';
 
 export default function ProfileCard() {
   const params = useParams();
   useEffect(() => {
-    if (!params.slug) return;
+    async function fetchData() {
+      const response = await axios.get(`/profile_cards/${params.slug}`);
+    }
 
-    const fetchData = async () => {
-      const res = await axios.get(`profile_cards/${params.slug}`);
-    };
-  });
+    fetchData();
+  }, []);
+
+  return <></>;
 }

--- a/frontend/src/components/ui/profile_cards/ProfileCard.jsx
+++ b/frontend/src/components/ui/profile_cards/ProfileCard.jsx
@@ -1,3 +1,6 @@
+import { useParams } from "react-router";
+import { useState, useEffect } from "react";
+
 export default function ProfileCard() {
-  
+  const params = useParams();
 }

--- a/frontend/src/components/ui/profile_cards/ProfileCard.jsx
+++ b/frontend/src/components/ui/profile_cards/ProfileCard.jsx
@@ -1,0 +1,3 @@
+export default function ProfileCard() {
+  
+}

--- a/frontend/src/components/ui/profile_cards/ProfileCard.jsx
+++ b/frontend/src/components/ui/profile_cards/ProfileCard.jsx
@@ -1,20 +1,44 @@
 import { useParams } from 'react-router';
 import React, { useState, useEffect } from 'react';
 import axios from './../../../../api/lib/apiClient';
+import Layout from '@/components/layout/Layout';
+import Header from '@/components/common/Header';
+import CreateGridBody from '@/components/layout/CreateGridBody';
 
 export default function ProfileCard() {
   const params = useParams();
   const [albums, setAlbums] = useState(null);
-  const [profileCard, setProfileCard] = useState(null);
+  const [bgColor, setBgColor] = useState(null);
+  const [displayName, setDisplayName] = useState(null);
+  const [gridRows, setGridRows] = useState(null);
+  const [gridColumns, setGridColumns] = useState(null);
   useEffect(() => {
     async function fetchData() {
       const response = await axios.get(`/profile_cards/${params.slug}`);
       setAlbums(response.data.albums);
-      setProfileCard(response.data.profileCard);
+      setBgColor(response.data.profileCard.bgColor);
+      setDisplayName(response.data.profileCard.displayName);
+      setGridRows(response.data.profileCard.gridRows);
+      setGridColumns(response.data.profileCard.gridColumns);
     }
 
     fetchData();
   }, []);
 
-  return <></>;
+  return (
+    <>
+      {albums &&
+        albums.map((album, index) => {
+          return <div key={index}>{album.name}</div>;
+        })}
+      <div>{bgColor}</div>
+      <div>{displayName}</div>
+      <div>{gridColumns}</div>
+      <div>{gridRows}</div>
+      {/* <Layout color={profileCard.bgColor}>
+        <Header />
+        <CreateGridBody setColor={setColor} color={bgColor} />
+      </Layout> */}
+    </>
+  );
 }

--- a/frontend/src/components/ui/profile_cards/ProfileCard.jsx
+++ b/frontend/src/components/ui/profile_cards/ProfileCard.jsx
@@ -52,6 +52,11 @@ export default function ProfileCard() {
                   );
                 })}
             </div>
+            <div className="mt-2 w-full text-right">
+              <div className="inline-block rounded-lg bg-white px-4 py-2 font-bold text-black">
+                <span className="text-gray-500">by</span> {displayName}
+              </div>
+            </div>
           </div>
         </div>
       </Layout>

--- a/frontend/src/components/ui/profile_cards/ProfileCard.jsx
+++ b/frontend/src/components/ui/profile_cards/ProfileCard.jsx
@@ -1,6 +1,14 @@
-import { useParams } from "react-router";
-import { useState, useEffect } from "react";
+import { useParams } from 'react-router';
+import { useState, useEffect } from 'react';
+import axios from 'axios';
 
 export default function ProfileCard() {
   const params = useParams();
+  useEffect(() => {
+    if (!params.slug) return;
+
+    const fetchData = async () => {
+      const res = await axios.get(`profile_cards/${params.slug}`);
+    };
+  });
 }

--- a/frontend/src/components/ui/profile_cards/ProfileCard.jsx
+++ b/frontend/src/components/ui/profile_cards/ProfileCard.jsx
@@ -37,7 +37,7 @@ export default function ProfileCard() {
                 albums.map((album, index) => {
                   return (
                     <div key={index}>
-                      <a href={album.externalUrl}>
+                      <a href={album.externalUrl} target="_blank">
                         <div className="aspect-square rounded-xl bg-[#0E1012]">
                           <div>
                             <img

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,12 +3,14 @@ import { createRoot } from 'react-dom/client';
 import { BrowserRouter, Routes, Route } from 'react-router';
 import './index.css';
 import App from './App.jsx';
+import ProfileCard from './components/ui/profile_cards/ProfileCard';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<App />} />
+        <Route path="music/:slug" element={<ProfileCard />} />
       </Routes>
     </BrowserRouter>
   </StrictMode>,

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router';
 import './index.css';
 import App from './App.jsx';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 );

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -1,13 +1,15 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import { BrowserRouter } from 'react-router';
+import { BrowserRouter, Routes, Route } from 'react-router';
 import './index.css';
 import App from './App.jsx';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
     <BrowserRouter>
-      <App />
+      <Routes>
+        <Route path="/" element={<App />} />
+      </Routes>
     </BrowserRouter>
   </StrictMode>,
 );


### PR DESCRIPTION
## 概要
生成されたリンク先のプロフィールカード詳細画面の表示を実装しました。

## 変更点
- `react-router`の導入(v7のdeclarative mode)
- `/music/:slug`のルーティング
- プロフィールカード詳細画面のコンポーネント`ProfileCard.jsx`の新規作成
- `useEffect`での該当プロフィールカードのデータの取得・表示
- グリッドに割り当てられたアルバムをクリックするとSpotifyの該当のアルバムの楽曲が聴ける画面へ遷移する処理の追加