### PR TITLE
[update] モバイルサイズ時のCSSを適用 #15

### DIFF
--- a/frontend/src/components/layout/CreateGridBody.jsx
+++ b/frontend/src/components/layout/CreateGridBody.jsx
@@ -167,7 +167,7 @@ export default function CreateGridBody({ color, setColor }) {
   }
   return (
     <>
-      <div className="flex flex-col items-center justify-center px-4 md:flex-row md:items-start md:justify-start md:px-16">
+      <div className="flex flex-col items-center justify-center px-4 lg:flex-row lg:items-start lg:justify-start lg:px-16">
         <DndContext
           sensors={sensors}
           collisionDetection={pointerWithin}

--- a/frontend/src/components/layout/CreateGridBody.jsx
+++ b/frontend/src/components/layout/CreateGridBody.jsx
@@ -167,7 +167,7 @@ export default function CreateGridBody({ color, setColor }) {
   }
   return (
     <>
-      <div className="flex md:px-16">
+      <div className="md:flex md:px-16">
         <DndContext
           sensors={sensors}
           collisionDetection={pointerWithin}

--- a/frontend/src/components/layout/CreateGridBody.jsx
+++ b/frontend/src/components/layout/CreateGridBody.jsx
@@ -3,8 +3,10 @@ import axios from './../../../api/lib/apiClient';
 import {
   DndContext,
   closestCenter,
+  pointerWithin,
   KeyboardSensor,
   PointerSensor,
+  TouchSensor,
   useSensor,
   useSensors,
 } from '@dnd-kit/core';
@@ -16,6 +18,7 @@ export default function CreateGridBody({ color, setColor }) {
   const [disabledCreateSettingButton, setDisabledCreateSettingButton] = useState(true);
   const sensors = useSensors(
     useSensor(PointerSensor),
+    useSensor(TouchSensor),
     useSensor(KeyboardSensor, {
       coordinateGetter: sortableKeyboardCoordinates,
     }),
@@ -164,10 +167,10 @@ export default function CreateGridBody({ color, setColor }) {
   }
   return (
     <>
-      <div className="flex px-16">
+      <div className="flex md:px-16">
         <DndContext
           sensors={sensors}
-          collisionDetection={closestCenter}
+          collisionDetection={pointerWithin}
           onDragStart={handleDragStart}
           onDragEnd={handleDragEnd}
         >

--- a/frontend/src/components/layout/CreateGridBody.jsx
+++ b/frontend/src/components/layout/CreateGridBody.jsx
@@ -167,7 +167,7 @@ export default function CreateGridBody({ color, setColor }) {
   }
   return (
     <>
-      <div className="md:flex md:px-16">
+      <div className="flex flex-col items-center justify-center px-4 md:flex-row md:items-start md:justify-start md:px-16">
         <DndContext
           sensors={sensors}
           collisionDetection={pointerWithin}

--- a/frontend/src/components/ui/album_grid_editor/Album.jsx
+++ b/frontend/src/components/ui/album_grid_editor/Album.jsx
@@ -11,6 +11,7 @@ export default function Album({ id, src, alt, spotifyId }) {
     transform: CSS.Transform.toString(transform),
     transition,
     opacity: isDragging ? 0.3 : 1,
+    touchAction: 'none',
   };
 
   return (

--- a/frontend/src/components/ui/album_grid_editor/AlbumGridEditor.jsx
+++ b/frontend/src/components/ui/album_grid_editor/AlbumGridEditor.jsx
@@ -52,7 +52,7 @@ export default function AlbumGridEditor({
     );
   }
   return (
-    <div className="order-1 mb-32 md:h-screen w-full items-center justify-center md:order-2 md:flex md:w-3/5">
+    <div className="order-1 mb-32 md:mb-0 md:h-screen w-full items-center justify-center md:order-2 md:flex md:w-3/5">
       <div>
         <Toaster />
       </div>

--- a/frontend/src/components/ui/album_grid_editor/AlbumGridEditor.jsx
+++ b/frontend/src/components/ui/album_grid_editor/AlbumGridEditor.jsx
@@ -56,7 +56,7 @@ export default function AlbumGridEditor({
       <div>
         <Toaster />
       </div>
-      <div className="mx-4 flex aspect-square w-3/4">
+      <div className="md:mx-4 flex aspect-square w-3/4">
         <div className="h-full p-12">
           <DropAlbumGrid assignedAlbums={assignedAlbums} />
           <div className="mt-4 text-right">

--- a/frontend/src/components/ui/album_grid_editor/AlbumGridEditor.jsx
+++ b/frontend/src/components/ui/album_grid_editor/AlbumGridEditor.jsx
@@ -52,13 +52,13 @@ export default function AlbumGridEditor({
     );
   }
   return (
-    <div className="order-1 mb-4 w-full items-center justify-center md:order-2 md:mb-0 md:flex md:h-screen md:w-3/5">
+    <div className="order-1 mb-4 w-full items-center justify-center lg:order-2 lg:mb-0 lg:flex lg:h-screen lg:w-3/5">
       <div>
         <Toaster />
       </div>
-      <div className="md:mx-4 md:flex md:aspect-square md:w-3/4">
-        <div className="h-full md:p-12">
-          <div className="flex justify-center mt-12 md:mt-0">
+      <div className="lg:mx-4 lg:flex lg:aspect-square lg:w-3/4">
+        <div className="h-full lg:p-12">
+          <div className="flex justify-center mt-12 lg:mt-0">
             <DropAlbumGrid assignedAlbums={assignedAlbums} />
           </div>
           <div className="mt-4 text-right">
@@ -72,11 +72,11 @@ export default function AlbumGridEditor({
                     作成へ進む
                   </Button>
                 </DialogTrigger>
-                <DialogContent className="border border-[#646464] bg-[#151A1E] p-8 text-white md:p-12">
+                <DialogContent className="border border-[#646464] bg-[#151A1E] p-8 text-white lg:p-12">
                   {step === 'form' && (
                     <>
                       <DialogHeader>
-                        <DialogTitle className="text-md md:text-xl">
+                        <DialogTitle className="text-md lg:text-xl">
                           アイコンの設定（任意）
                         </DialogTitle>
                       </DialogHeader>
@@ -84,7 +84,7 @@ export default function AlbumGridEditor({
                         <Uploader setAvatarBlob={setAvatarBlob} />
                       </div>
                       <DialogHeader className="mt-4">
-                        <DialogTitle className="text-md md:text-xl">
+                        <DialogTitle className="text-md lg:text-xl">
                           表示するユーザ名の設定（必須）
                         </DialogTitle>
                       </DialogHeader>
@@ -123,21 +123,21 @@ export default function AlbumGridEditor({
                   {step === 'success' && (
                     <div>
                       <DialogHeader className="mt-4">
-                        <DialogTitle className="text-sm md:text-xl">
+                        <DialogTitle className="text-sm lg:text-xl">
                           リンクの生成が完了しました！🎉
                         </DialogTitle>
                         <DialogDescription className="text-md font-semibold">
                           コピーしてSNSのプロフィールに貼りましょう!!
                         </DialogDescription>
                       </DialogHeader>
-                      <div className="mt-4 rounded-xl bg-gray-800 text-sm text-white md:text-xl">
+                      <div className="mt-4 rounded-xl bg-gray-800 text-sm text-white lg:text-xl">
                         <div className="flex items-center justify-between p-4">
                           <div id="txt" className="">
                             https://topcore.me/music/{slug}
                           </div>
                           <button
                             onClick={onCopyClipboardClick}
-                            className="aspect-square h-6 rounded-sm bg-white text-black hover:bg-gray-200 md:h-8"
+                            className="aspect-square h-6 rounded-sm bg-white text-black hover:bg-gray-200 lg:h-8"
                           >
                             <FontAwesomeIcon icon={faClipboard} />
                           </button>
@@ -150,7 +150,7 @@ export default function AlbumGridEditor({
             </Dialog>
           </div>
         </div>
-        <div className="h-full md:w-1/4">
+        <div className="h-full lg:w-1/4">
           <ColorPalette color={color} setColor={setColor} />
         </div>
       </div>

--- a/frontend/src/components/ui/album_grid_editor/AlbumGridEditor.jsx
+++ b/frontend/src/components/ui/album_grid_editor/AlbumGridEditor.jsx
@@ -52,12 +52,12 @@ export default function AlbumGridEditor({
     );
   }
   return (
-    <div className="order-1 mb-32 md:mb-0 md:h-screen w-full items-center justify-center md:order-2 md:flex md:w-3/5">
+    <div className="order-1 mb-4 md:mb-0 md:h-screen w-full items-center justify-center md:order-2 md:flex md:w-3/5">
       <div>
         <Toaster />
       </div>
-      <div className="flex aspect-square w-3/4 md:mx-4">
-        <div className="h-full p-12">
+      <div className="md:flex md:aspect-square md:w-3/4 md:mx-4">
+        <div className="h-full px-12 pt-12 md:p-12">
           <DropAlbumGrid assignedAlbums={assignedAlbums} />
           <div className="mt-4 text-right">
             <Dialog>
@@ -142,7 +142,7 @@ export default function AlbumGridEditor({
             </Dialog>
           </div>
         </div>
-        <div className="h-full w-1/4">
+        <div className="h-full md:w-1/4">
           <ColorPalette color={color} setColor={setColor} />
         </div>
       </div>

--- a/frontend/src/components/ui/album_grid_editor/AlbumGridEditor.jsx
+++ b/frontend/src/components/ui/album_grid_editor/AlbumGridEditor.jsx
@@ -52,13 +52,15 @@ export default function AlbumGridEditor({
     );
   }
   return (
-    <div className="order-1 mb-4 md:mb-0 md:h-screen w-full items-center justify-center md:order-2 md:flex md:w-3/5">
+    <div className="order-1 mb-4 w-full items-center justify-center md:order-2 md:mb-0 md:flex md:h-screen md:w-3/5">
       <div>
         <Toaster />
       </div>
-      <div className="md:flex md:aspect-square md:w-3/4 md:mx-4">
-        <div className="h-full px-12 pt-12 md:p-12">
-          <DropAlbumGrid assignedAlbums={assignedAlbums} />
+      <div className="md:mx-4 md:flex md:aspect-square md:w-3/4">
+        <div className="h-full md:p-12">
+          <div className="flex justify-center mt-12 md:mt-0">
+            <DropAlbumGrid assignedAlbums={assignedAlbums} />
+          </div>
           <div className="mt-4 text-right">
             <Dialog>
               <form>
@@ -70,17 +72,21 @@ export default function AlbumGridEditor({
                     作成へ進む
                   </Button>
                 </DialogTrigger>
-                <DialogContent className="border border-[#646464] bg-[#151A1E] p-8 md:p-12 text-white">
+                <DialogContent className="border border-[#646464] bg-[#151A1E] p-8 text-white md:p-12">
                   {step === 'form' && (
                     <>
                       <DialogHeader>
-                        <DialogTitle className="text-md md:text-xl">アイコンの設定（任意）</DialogTitle>
+                        <DialogTitle className="text-md md:text-xl">
+                          アイコンの設定（任意）
+                        </DialogTitle>
                       </DialogHeader>
                       <div>
                         <Uploader setAvatarBlob={setAvatarBlob} />
                       </div>
                       <DialogHeader className="mt-4">
-                        <DialogTitle className="text-md md:text-xl">表示するユーザ名の設定（必須）</DialogTitle>
+                        <DialogTitle className="text-md md:text-xl">
+                          表示するユーザ名の設定（必須）
+                        </DialogTitle>
                       </DialogHeader>
                       <div>
                         <Input onChange={handleDisplayNameChange} />
@@ -124,12 +130,14 @@ export default function AlbumGridEditor({
                           コピーしてSNSのプロフィールに貼りましょう!!
                         </DialogDescription>
                       </DialogHeader>
-                      <div className="mt-4 rounded-xl bg-gray-800 text-sm md:text-xl text-white">
+                      <div className="mt-4 rounded-xl bg-gray-800 text-sm text-white md:text-xl">
                         <div className="flex items-center justify-between p-4">
-                          <div id="txt" className="">https://topcore.me/music/{slug}</div>
+                          <div id="txt" className="">
+                            https://topcore.me/music/{slug}
+                          </div>
                           <button
                             onClick={onCopyClipboardClick}
-                            className="aspect-square h-6 md:h-8 rounded-sm bg-white text-black hover:bg-gray-200"
+                            className="aspect-square h-6 rounded-sm bg-white text-black hover:bg-gray-200 md:h-8"
                           >
                             <FontAwesomeIcon icon={faClipboard} />
                           </button>

--- a/frontend/src/components/ui/album_grid_editor/AlbumGridEditor.jsx
+++ b/frontend/src/components/ui/album_grid_editor/AlbumGridEditor.jsx
@@ -70,7 +70,7 @@ export default function AlbumGridEditor({
                     作成へ進む
                   </Button>
                 </DialogTrigger>
-                <DialogContent className="border border-[#646464] bg-[#151A1E] p-12 text-white">
+                <DialogContent className="border border-[#646464] bg-[#151A1E] p-8 md:p-12 text-white">
                   {step === 'form' && (
                     <>
                       <DialogHeader>
@@ -117,19 +117,19 @@ export default function AlbumGridEditor({
                   {step === 'success' && (
                     <div>
                       <DialogHeader className="mt-4">
-                        <DialogTitle className="text-xl">
+                        <DialogTitle className="text-sm md:text-xl">
                           リンクの生成が完了しました！🎉
                         </DialogTitle>
                         <DialogDescription className="text-md font-semibold">
                           コピーしてSNSのプロフィールに貼りましょう!!
                         </DialogDescription>
                       </DialogHeader>
-                      <div className="mt-4 rounded-xl bg-gray-800 text-xl text-white">
+                      <div className="mt-4 rounded-xl bg-gray-800 text-sm md:text-xl text-white">
                         <div className="flex items-center justify-between p-4">
-                          <div id="txt">https://topcore.me/music/{slug}</div>
+                          <div id="txt" className="">https://topcore.me/music/{slug}</div>
                           <button
                             onClick={onCopyClipboardClick}
-                            className="aspect-square h-8 rounded-sm bg-white text-black hover:bg-gray-200"
+                            className="aspect-square h-6 md:h-8 rounded-sm bg-white text-black hover:bg-gray-200"
                           >
                             <FontAwesomeIcon icon={faClipboard} />
                           </button>

--- a/frontend/src/components/ui/album_grid_editor/AlbumGridEditor.jsx
+++ b/frontend/src/components/ui/album_grid_editor/AlbumGridEditor.jsx
@@ -52,7 +52,7 @@ export default function AlbumGridEditor({
     );
   }
   return (
-    <div className="flex h-screen w-3/5 items-center justify-center">
+    <div className="md:flex h-screen w-full md:w-3/5 items-center justify-center">
       <div>
         <Toaster />
       </div>

--- a/frontend/src/components/ui/album_grid_editor/AlbumGridEditor.jsx
+++ b/frontend/src/components/ui/album_grid_editor/AlbumGridEditor.jsx
@@ -74,13 +74,13 @@ export default function AlbumGridEditor({
                   {step === 'form' && (
                     <>
                       <DialogHeader>
-                        <DialogTitle>アイコンの設定（任意）</DialogTitle>
+                        <DialogTitle className="text-md md:text-xl">アイコンの設定（任意）</DialogTitle>
                       </DialogHeader>
                       <div>
                         <Uploader setAvatarBlob={setAvatarBlob} />
                       </div>
                       <DialogHeader className="mt-4">
-                        <DialogTitle>表示するユーザ名の設定（必須）</DialogTitle>
+                        <DialogTitle className="text-md md:text-xl">表示するユーザ名の設定（必須）</DialogTitle>
                       </DialogHeader>
                       <div>
                         <Input onChange={handleDisplayNameChange} />

--- a/frontend/src/components/ui/album_grid_editor/AlbumGridEditor.jsx
+++ b/frontend/src/components/ui/album_grid_editor/AlbumGridEditor.jsx
@@ -52,11 +52,11 @@ export default function AlbumGridEditor({
     );
   }
   return (
-    <div className="md:flex h-screen w-full md:w-3/5 items-center justify-center">
+    <div className="order-1 h-screen w-full items-center justify-center md:order-2 md:flex md:w-3/5">
       <div>
         <Toaster />
       </div>
-      <div className="md:mx-4 flex aspect-square w-3/4">
+      <div className="flex aspect-square w-3/4 md:mx-4">
         <div className="h-full p-12">
           <DropAlbumGrid assignedAlbums={assignedAlbums} />
           <div className="mt-4 text-right">

--- a/frontend/src/components/ui/album_grid_editor/AlbumGridEditor.jsx
+++ b/frontend/src/components/ui/album_grid_editor/AlbumGridEditor.jsx
@@ -52,7 +52,7 @@ export default function AlbumGridEditor({
     );
   }
   return (
-    <div className="order-1 h-screen w-full items-center justify-center md:order-2 md:flex md:w-3/5">
+    <div className="order-1 mb-32 md:h-screen w-full items-center justify-center md:order-2 md:flex md:w-3/5">
       <div>
         <Toaster />
       </div>

--- a/frontend/src/components/ui/album_grid_editor/DropAlbumGrid.jsx
+++ b/frontend/src/components/ui/album_grid_editor/DropAlbumGrid.jsx
@@ -3,7 +3,7 @@ import Album from './Album';
 
 export default function DropAlbumGrid({ assignedAlbums }) {
   return (
-    <div className="aspect-square w-100">
+    <div className="aspect-square w-60 md:w-100">
       <div className="grid grid-cols-3 grid-rows-3 gap-2">
         <SortableContext items={assignedAlbums.map((a) => a.id)} strategy={rectSortingStrategy}>
           {assignedAlbums.map((album) => {

--- a/frontend/src/components/ui/album_grid_editor/DropAlbumGrid.jsx
+++ b/frontend/src/components/ui/album_grid_editor/DropAlbumGrid.jsx
@@ -3,7 +3,7 @@ import Album from './Album';
 
 export default function DropAlbumGrid({ assignedAlbums }) {
   return (
-    <div className="aspect-square w-60 md:w-100">
+    <div className="aspect-square w-60 lg:w-100">
       <div className="grid grid-cols-3 grid-rows-3 gap-2">
         <SortableContext items={assignedAlbums.map((a) => a.id)} strategy={rectSortingStrategy}>
           {assignedAlbums.map((album) => {

--- a/frontend/src/components/ui/album_search/AlbumSearchCard.jsx
+++ b/frontend/src/components/ui/album_search/AlbumSearchCard.jsx
@@ -12,7 +12,7 @@ export default function AlbumSearchCard({
   isDragging,
 }) {
   return (
-    <div className="flex h-screen w-2/5 items-center">
+    <div className="md:flex h-screen  md:w-2/5 items-center hidden">
       <div className="mx-4 h-4/5 w-full rounded-xl border border-[#2D2D2D] bg-[#1E1E1E] shadow-xl shadow-gray-900">
         <div className="h-full p-12">
           <SearchBar onSearchClick={onSearchClick} setSearchAlbumInput={setSearchAlbumInput} />

--- a/frontend/src/components/ui/album_search/AlbumSearchCard.jsx
+++ b/frontend/src/components/ui/album_search/AlbumSearchCard.jsx
@@ -12,7 +12,7 @@ export default function AlbumSearchCard({
   isDragging,
 }) {
   return (
-    <div className="order-2 h-screen w-80 lg:order-1 lg:flex lg:w-2/5 lg:items-center">
+    <div className="order-2 h-screen w-full lg:order-1 lg:flex lg:w-2/5 lg:items-center">
       <div className="h-4/5 w-full rounded-xl border border-[#2D2D2D] bg-[#1E1E1E] shadow-xl shadow-gray-900 md:mx-4">
         <div className="h-full p-12">
           <SearchBar onSearchClick={onSearchClick} setSearchAlbumInput={setSearchAlbumInput} />

--- a/frontend/src/components/ui/album_search/AlbumSearchCard.jsx
+++ b/frontend/src/components/ui/album_search/AlbumSearchCard.jsx
@@ -13,7 +13,7 @@ export default function AlbumSearchCard({
 }) {
   return (
     <div className="md:flex h-screen w-80  md:w-2/5 md:items-center">
-      <div className="mx-4 h-4/5 w-full rounded-xl border border-[#2D2D2D] bg-[#1E1E1E] shadow-xl shadow-gray-900">
+      <div className="md:mx-4 h-4/5 w-full rounded-xl border border-[#2D2D2D] bg-[#1E1E1E] shadow-xl shadow-gray-900">
         <div className="h-full p-12">
           <SearchBar onSearchClick={onSearchClick} setSearchAlbumInput={setSearchAlbumInput} />
           <SearchResult

--- a/frontend/src/components/ui/album_search/AlbumSearchCard.jsx
+++ b/frontend/src/components/ui/album_search/AlbumSearchCard.jsx
@@ -12,7 +12,7 @@ export default function AlbumSearchCard({
   isDragging,
 }) {
   return (
-    <div className="md:flex h-screen  md:w-2/5 items-center hidden">
+    <div className="md:flex h-screen w-80  md:w-2/5 md:items-center">
       <div className="mx-4 h-4/5 w-full rounded-xl border border-[#2D2D2D] bg-[#1E1E1E] shadow-xl shadow-gray-900">
         <div className="h-full p-12">
           <SearchBar onSearchClick={onSearchClick} setSearchAlbumInput={setSearchAlbumInput} />

--- a/frontend/src/components/ui/album_search/AlbumSearchCard.jsx
+++ b/frontend/src/components/ui/album_search/AlbumSearchCard.jsx
@@ -12,7 +12,7 @@ export default function AlbumSearchCard({
   isDragging,
 }) {
   return (
-    <div className="order-2 h-screen w-80 md:order-1 md:flex md:w-2/5 md:items-center">
+    <div className="order-2 h-screen w-80 lg:order-1 lg:flex lg:w-2/5 lg:items-center">
       <div className="h-4/5 w-full rounded-xl border border-[#2D2D2D] bg-[#1E1E1E] shadow-xl shadow-gray-900 md:mx-4">
         <div className="h-full p-12">
           <SearchBar onSearchClick={onSearchClick} setSearchAlbumInput={setSearchAlbumInput} />

--- a/frontend/src/components/ui/album_search/AlbumSearchCard.jsx
+++ b/frontend/src/components/ui/album_search/AlbumSearchCard.jsx
@@ -12,8 +12,8 @@ export default function AlbumSearchCard({
   isDragging,
 }) {
   return (
-    <div className="md:flex h-screen w-80  md:w-2/5 md:items-center">
-      <div className="md:mx-4 h-4/5 w-full rounded-xl border border-[#2D2D2D] bg-[#1E1E1E] shadow-xl shadow-gray-900">
+    <div className="order-2 h-screen w-80 md:order-1 md:flex md:w-2/5 md:items-center">
+      <div className="h-4/5 w-full rounded-xl border border-[#2D2D2D] bg-[#1E1E1E] shadow-xl shadow-gray-900 md:mx-4">
         <div className="h-full p-12">
           <SearchBar onSearchClick={onSearchClick} setSearchAlbumInput={setSearchAlbumInput} />
           <SearchResult

--- a/frontend/src/components/ui/album_search/SearchResult.jsx
+++ b/frontend/src/components/ui/album_search/SearchResult.jsx
@@ -10,7 +10,7 @@ export default function SearchResult({ albums, isDragging, activeId, activeAlt, 
           {albums
             ? albums.map((album, index) => {
                 return (
-                  <div key={album.spotifyId}>
+                  <div key={album.spotifyId} className="touch-none">
                     <Draggable id={index}>
                       <AlbumImage src={album.imageUrl} alt={album.name} />
                     </Draggable>

--- a/frontend/src/components/ui/color_palette/ColorPalette.jsx
+++ b/frontend/src/components/ui/color_palette/ColorPalette.jsx
@@ -2,8 +2,8 @@ import Color from './Color';
 
 export default function ColorPalette({ color, setColor }) {
   return (
-    <div className="mt-8 md:h-2/3 md:w-3/5 justify-center md:rounded-2xl md:bg-[#151A1E] md:flex">
-      <div className="my-4 grid grid-cols-9 md:grid-cols-1 gap-1">
+    <div className="mt-8 lg:h-2/3 lg:w-3/5 justify-center lg:rounded-2xl lg:bg-[#151A1E] lg:flex">
+      <div className="my-4 grid grid-cols-9 lg:grid-cols-1 gap-1">
         <Color color={'#121212'} setColor={setColor} />
         <Color color={'#3E7CB6'} setColor={setColor} />
         <Color color={'#72A7D3'} setColor={setColor} />
@@ -12,7 +12,7 @@ export default function ColorPalette({ color, setColor }) {
         <Color color={'#DA7742'} setColor={setColor} />
         <Color color={'#F4A2BB'} setColor={setColor} />
         <Color color={'#FFF3E3'} setColor={setColor} />
-        <div className="h-8 w-8 border border-gray-700 md:border-gray-400" style={{ background: color }}>
+        <div className="h-8 w-8 border border-gray-700 lg:border-gray-400" style={{ background: color }}>
           <input
             type="color"
             value={color}

--- a/frontend/src/components/ui/color_palette/ColorPalette.jsx
+++ b/frontend/src/components/ui/color_palette/ColorPalette.jsx
@@ -2,8 +2,8 @@ import Color from './Color';
 
 export default function ColorPalette({ color, setColor }) {
   return (
-    <div className="mt-8 h-2/3 w-3/5 justify-center rounded-2xl bg-[#151A1E] md:flex">
-      <div className="my-4 grid grid-cols-1 gap-1">
+    <div className="mt-8 md:h-2/3 md:w-3/5 justify-center rounded-2xl bg-[#151A1E] md:flex">
+      <div className="my-4 grid grid-cols-9 md:grid-cols-1 gap-1">
         <Color color={'#121212'} setColor={setColor} />
         <Color color={'#3E7CB6'} setColor={setColor} />
         <Color color={'#72A7D3'} setColor={setColor} />

--- a/frontend/src/components/ui/color_palette/ColorPalette.jsx
+++ b/frontend/src/components/ui/color_palette/ColorPalette.jsx
@@ -2,7 +2,7 @@ import Color from './Color';
 
 export default function ColorPalette({ color, setColor }) {
   return (
-    <div className="mt-8 md:h-2/3 md:w-3/5 justify-center rounded-2xl bg-[#151A1E] md:flex">
+    <div className="mt-8 md:h-2/3 md:w-3/5 justify-center md:rounded-2xl md:bg-[#151A1E] md:flex">
       <div className="my-4 grid grid-cols-9 md:grid-cols-1 gap-1">
         <Color color={'#121212'} setColor={setColor} />
         <Color color={'#3E7CB6'} setColor={setColor} />
@@ -12,7 +12,7 @@ export default function ColorPalette({ color, setColor }) {
         <Color color={'#DA7742'} setColor={setColor} />
         <Color color={'#F4A2BB'} setColor={setColor} />
         <Color color={'#FFF3E3'} setColor={setColor} />
-        <div className="h-8 w-8 border border-gray-400" style={{ background: color }}>
+        <div className="h-8 w-8 border border-gray-700 md:border-gray-400" style={{ background: color }}>
           <input
             type="color"
             value={color}

--- a/frontend/src/components/ui/color_palette/ColorPalette.jsx
+++ b/frontend/src/components/ui/color_palette/ColorPalette.jsx
@@ -2,7 +2,7 @@ import Color from './Color';
 
 export default function ColorPalette({ color, setColor }) {
   return (
-    <div className="mt-8 flex h-2/3 w-3/5 justify-center rounded-2xl bg-[#151A1E]">
+    <div className="mt-8 hidden md:flex h-2/3 w-3/5 justify-center rounded-2xl bg-[#151A1E]">
       <div className="my-4 grid grid-cols-1 gap-1">
         <Color color={'#121212'} setColor={setColor} />
         <Color color={'#3E7CB6'} setColor={setColor} />

--- a/frontend/src/components/ui/color_palette/ColorPalette.jsx
+++ b/frontend/src/components/ui/color_palette/ColorPalette.jsx
@@ -2,7 +2,7 @@ import Color from './Color';
 
 export default function ColorPalette({ color, setColor }) {
   return (
-    <div className="mt-8 hidden md:flex h-2/3 w-3/5 justify-center rounded-2xl bg-[#151A1E]">
+    <div className="mt-8 h-2/3 w-3/5 justify-center rounded-2xl bg-[#151A1E] md:flex">
       <div className="my-4 grid grid-cols-1 gap-1">
         <Color color={'#121212'} setColor={setColor} />
         <Color color={'#3E7CB6'} setColor={setColor} />

--- a/frontend/src/components/ui/profile_cards/ProfileCard.jsx
+++ b/frontend/src/components/ui/profile_cards/ProfileCard.jsx
@@ -31,7 +31,7 @@ export default function ProfileCard() {
       <Layout color={bgColor}>
         <Header />
         <div className="flex min-h-screen items-center justify-center">
-          <div className="aspect-square w-110">
+          <div className="aspect-square w-5/6 lg:w-110">
             <div className="grid grid-cols-3 grid-rows-3 gap-2">
               {albums &&
                 albums.map((album, index) => {

--- a/frontend/src/components/ui/upload_image/Uploader.jsx
+++ b/frontend/src/components/ui/upload_image/Uploader.jsx
@@ -58,7 +58,7 @@ const Uploader = ({ setAvatarBlob }) => {
 
   return (
     <div className="flex">
-      <div className="mx-auto mt-4 flex w-full max-w-xl items-center justify-center space-y-4">
+      <div className="mx-auto md:mt-4 flex w-full max-w-xl items-center justify-center space-y-4">
         {/* アップロードした画像が表示される場所 */}
         <div
           className="mt-4 mr-4 relative overflow-hidden rounded border border-gray-400 bg-gray-100"

--- a/frontend/src/components/ui/upload_image/Uploader.jsx
+++ b/frontend/src/components/ui/upload_image/Uploader.jsx
@@ -58,7 +58,7 @@ const Uploader = ({ setAvatarBlob }) => {
 
   return (
     <div className="flex">
-      <div className="mx-auto md:mt-4 flex w-full max-w-xl items-center justify-center space-y-4">
+      <div className="mx-auto lg:mt-4 flex w-full max-w-xl items-center justify-center space-y-4">
         {/* アップロードした画像が表示される場所 */}
         <div
           className="mt-4 mr-4 relative overflow-hidden rounded border border-gray-400 bg-gray-100"


### PR DESCRIPTION
## 概要
モバイルサイズ時のCSSを適用するようにしました。
適用範囲は、最小〜lg(`64rem (1024px)`)の範囲です。

## 変更点
- レスポンシブデザインにするため、lg未満とlg以上で適用されるCSSを異なるものに変更
- モバイルサイズ時のdnd-kitにおいて、タッチした位置とDragDisplayの位置が異なることによって操作感が悪くなるという不具合が発生していたので、`collisionDetection`(dnd可能なUI同士の衝突判定)を`pointerWithin`(ユーザーの指（またはマウス）の座標がどの`Droppable`の境界内にあるかを判定してくれるdnd-kitのロジック)にすることで修正
- - lg未満の画面サイズにおいては、以下の添付画像のように各UIが縦に並ぶように変更

<img width="280" alt="スクリーンショット 2025-06-23 16 19 38" src="https://github.com/user-attachments/assets/0c940f30-65c9-45b1-a65e-bcd9a275f267" />
