### PR TITLE
[fix] アルバムを全て割り当てた上で更にアルバムを上書きすると「作成へ進む」ボタンが無効化される不具合 を修正

### DIFF
--- a/frontend/src/components/layout/CreateGridBody.jsx
+++ b/frontend/src/components/layout/CreateGridBody.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import axios from './../../../api/lib/apiClient';
 import {
   DndContext,
@@ -55,6 +55,12 @@ export default function CreateGridBody({ color, setColor }) {
   // [ユーザー名, 画像アイコン]の設定モーダル -> 生成されたリンクの表示モーダル のステップの管理
   const [step, setStep] = useState('form');
 
+  useEffect(() => {
+    // 全てのグリッドのマスにアルバムが割り当てられているかのチェック
+    const allAssigned = assignedAlbums.every((album) => album.src && album.alt && album.spotifyId);
+    setDisabledCreateSettingButton(!allAssigned);
+  }, [assignedAlbums]);
+
   async function onSearchClick() {
     const res = await axios.get('/albums/search', { params: { name: searchAlbumInput } });
     const albums = res.data.searchedAlbums;
@@ -110,20 +116,6 @@ export default function CreateGridBody({ color, setColor }) {
       const newIndex = assignedAlbums.findIndex((album) => album.id === over.id);
       const reordered = arrayMove(assignedAlbums, oldIndex, newIndex);
       setAssignedAlbums(reordered);
-    }
-
-    // グリッドの中に全てアルバムが割り当てられた時のみ、作成へ進む]ボタンを有効化
-    let assignedCellCount = 0;
-    assignedAlbums.forEach((album) => {
-      if (album.src && album.alt && album.spotifyId) {
-        assignedCellCount++;
-      }
-    });
-
-    if (assignedCellCount === assignedAlbums.length - 1) {
-      setDisabledCreateSettingButton(false);
-    } else {
-      setDisabledCreateSettingButton(true);
     }
   }
 


### PR DESCRIPTION
## 概要
アルバムを全て割り当てた上で更にアルバムを上書きすると「作成へ進む」ボタンが無効化される不具合を修正しました。

## 原因
`setAssignedAlbums(....)`の直後に「作成へ進む」ボタンの有効化, 無効化の切り替え処理を書いていたが、stateが更新される前にその処理が走ってしまっていたことで期待するstateの値と数値1だけズレが生じていた。

`if (assignedCellCount === assignedAlbums.length - 1)`としていたため、数値が1ズレたことにより期待していた数値よりも1だけオーバーしてしまいアルバムの上書きの際に無効化されてしまっていた。

## 修正
まずこの処理が冗長的なように思えたので、`assignedAlbums`に対して`every`メソッドを用いることで、全てのアルバムが割り当てられているかのチェックを行う処理に変更した。

次に、stateの監視が上手くいっていなかったことが原因なので、`useEffect`でステートの変更を監視するように修正しました。