### PR TITLE
[add] アルバム詳細画面の表示時のアルバム情報の一時的なキャッシュの処理の追加 #57

### DIFF
--- a/backend/app/controllers/api/v1/profile_cards_controller.rb
+++ b/backend/app/controllers/api/v1/profile_cards_controller.rb
@@ -17,35 +17,45 @@ class Api::V1::ProfileCardsController < ApplicationController
     end
     spotify_ids_str = spotify_ids_arr.join(',')
 
-    # アクセストークンの取得
-    response = HTTP.headers("Content-Type" => "application/x-www-form-urlencoded")
-              .post("https://accounts.spotify.com/api/token", form: {
-                grant_type: "client_credentials",
-                client_id: ENV['SPOTIFY_CLIENT_ID'],
-                client_secret: ENV['SPOTIFY_CLIENT_SECRET']
-              })
-    access_token = JSON.parse(response.body.to_s)["access_token"]
+    albums_cached_value = Rails.cache.read("#{spotify_ids_str}")
 
-    # アルバムの情報の取得
-    response = HTTP.headers("Authorization" => "Bearer #{access_token}")
-                .get("https://api.spotify.com/v1/albums?ids=#{spotify_ids_str}&market=JP")
-    assigned_albums = JSON.parse(response.body.to_s)
-    albums = []
-    assigned_albums["albums"].each do |album|
-      album_data = {
-                    name: album["name"],
-                    external_url: album["external_urls"]["spotify"],
-                    image_url: album["images"].second["url"]
-                  }
-      albums << album_data
+    if albums_cached_value.nil?
+      # アクセストークンの取得
+      response = HTTP.headers("Content-Type" => "application/x-www-form-urlencoded")
+                .post("https://accounts.spotify.com/api/token", form: {
+                  grant_type: "client_credentials",
+                  client_id: ENV['SPOTIFY_CLIENT_ID'],
+                  client_secret: ENV['SPOTIFY_CLIENT_SECRET']
+                })
+      access_token = JSON.parse(response.body.to_s)["access_token"]
+
+      # アルバムの情報の取得
+      response = HTTP.headers("Authorization" => "Bearer #{access_token}")
+                  .get("https://api.spotify.com/v1/albums?ids=#{spotify_ids_str}&market=JP")
+      assigned_albums = JSON.parse(response.body.to_s)
+      albums = []
+      assigned_albums["albums"].each do |album|
+        album_data = {
+                      name: album["name"],
+                      external_url: album["external_urls"]["spotify"],
+                      image_url: album["images"].second["url"]
+                    }
+        albums << album_data
+      end
+      profile_card = {
+        bg_color: profile_card.bg_color,
+        display_name: profile_card.display_name,
+        grid_rows: profile_card.grid_rows,
+        grid_columns: profile_card.grid_columns,
+        avatar: profile_card.avatar
+      }
+
+      # キャッシュに保存
+      Rails.cache.write("#{spotify_ids_str}", albums)
+    else
+      albums = albums_cached_value
     end
-    profile_card = {
-      bg_color: profile_card.bg_color,
-      display_name: profile_card.display_name,
-      grid_rows: profile_card.grid_rows,
-      grid_columns: profile_card.grid_columns,
-      avatar: profile_card.avatar
-    }
+
     render json: { profile_card: profile_card, albums: albums }
   end
 

--- a/backend/config/cache.yml
+++ b/backend/config/cache.yml
@@ -1,7 +1,7 @@
 default: &default
   store_options:
     # Cap age of oldest cache entry to fulfill retention policies
-    # max_age: <%= 60.days.to_i %>
+    max_age: <%= 3.days.to_i %>
     max_size: <%= 256.megabytes %>
     namespace: <%= Rails.env %>
 

--- a/frontend/src/components/layout/CreateGridBody.jsx
+++ b/frontend/src/components/layout/CreateGridBody.jsx
@@ -142,7 +142,6 @@ export default function CreateGridBody({ color, setColor }) {
     const res = await axios.post('/profile_cards', formData, {
       headers: { 'Content-Type': 'multipart/form-data' },
       onUploadProgress: (e) => {
-        console.log(e);
         if (!e.total) return;
         const percentCompleted = Math.round((e.loaded * 100) / e.total);
         setProgress(percentCompleted);


### PR DESCRIPTION
## 概要
アルバム詳細画面の表示時のアルバム情報の一時的なキャッシュの処理の追加
キャッシュストアにはSolid Cacheを使用

## 変更点
- `profile_cards#show`において、アルバムの情報がすでにキャッシュされていればその情報を読み取り、ない場合はSpotify Web APIより取得してキャッシュするという分岐処理を追加