### PR TITLE
[fix] 検索結果のアルバムをドラッグしながらでしかスクロールが出来ない不具合を修正 #88

### DIFF
--- a/frontend/src/components/layout/CreateGridBody.jsx
+++ b/frontend/src/components/layout/CreateGridBody.jsx
@@ -2,10 +2,9 @@ import { useState, useEffect } from 'react';
 import axios from './../../../api/lib/apiClient';
 import {
   DndContext,
-  closestCenter,
   pointerWithin,
   KeyboardSensor,
-  PointerSensor,
+  MouseSensor,
   TouchSensor,
   useSensor,
   useSensors,
@@ -17,8 +16,17 @@ import AlbumGridEditor from '../ui/album_grid_editor/AlbumGridEditor';
 export default function CreateGridBody({ color, setColor }) {
   const [disabledCreateSettingButton, setDisabledCreateSettingButton] = useState(true);
   const sensors = useSensors(
-    useSensor(PointerSensor),
-    useSensor(TouchSensor),
+    useSensor(MouseSensor, {
+      activationConstraint: {
+        distance: 8,
+      },
+    }),
+    useSensor(TouchSensor, {
+      activationConstraint: {
+        delay: 250,
+        tolerance: 8,
+      },
+    }),
     useSensor(KeyboardSensor, {
       coordinateGetter: sortableKeyboardCoordinates,
     }),

--- a/frontend/src/components/ui/album_search/SearchResult.jsx
+++ b/frontend/src/components/ui/album_search/SearchResult.jsx
@@ -10,7 +10,7 @@ export default function SearchResult({ albums, isDragging, activeId, activeAlt, 
           {albums
             ? albums.map((album, index) => {
                 return (
-                  <div key={album.spotifyId} className="touch-none">
+                  <div key={album.spotifyId}>
                     <Draggable id={index}>
                       <AlbumImage src={album.imageUrl} alt={album.name} />
                     </Draggable>


### PR DESCRIPTION
## 概要
検索結果のアルバムをドラッグしながらでしかスクロールが出来ない不具合を修正しました。

## 原因
dnd-kitの`PointSensor`はスクロールの制御よりもドラッグが優先されてしまうことが原因で、スクロールするためには必ずアルバムをドラッグしてからでしか出来ないようになっていました。

## 修正
`PointSensor`を削除して、`MouseSensor`と`TouchSensor`の併用に変更し、`TouchSensor`に「タップしてからどれくらいでドラッグするか」のオプションを指定する`delay`を追加してあげることで、「押してすぐ指を移動するとスクロール」「押して少ししてから指を移動するとアルバムのドラッグ」という処理として修正。

https://github.com/user-attachments/assets/a91d0db7-3a55-4128-9fcc-592681175b78

以下はdnd-kitの参考にしたドキュメント箇所です。
https://docs.dndkit.com/api-documentation/sensors/pointer#touch-action