### PR TITLE
[add] 本番環境用のbackendのDockerfileの追加 (本番環境のメモリアロケーターをmallocからjemallocに変更)

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,34 @@
+ARG RUBY_VERSION=3.4.4
+FROM ruby:$RUBY_VERSION-slim AS base
+
+WORKDIR /app
+
+RUN apt-get update -qq && \
+    apt-get install --no-install-recommends -y \
+      curl libjemalloc2 libvips postgresql-client \
+      git build-essential libpq-dev libyaml-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+ENV RAILS_ENV=production \
+    BUNDLE_PATH="/usr/local/bundle" \
+    BUNDLE_WITHOUT="development test"
+
+FROM base AS build
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+
+COPY . .
+
+FROM base
+COPY --from=build /usr/local/bundle /usr/local/bundle
+COPY --from=build /app /app
+
+RUN groupadd --system --gid 1000 rails && \
+    useradd rails --uid 1000 --gid 1000 --create-home --shell /bin/bash && \
+    chown -R rails:rails db log storage tmp
+USER 1000:1000
+
+ENTRYPOINT ["/app/bin/docker-entrypoint"]
+
+EXPOSE 3000
+CMD ["./bin/rails", "server", "-b", "0.0.0.0"]


### PR DESCRIPTION
## 概要
本番環境のメモリアロケーターをmallocからjemallocに変更にして、メモリの断片化によるメモリの肥大化を抑えたいと考えたので、そのための本番環境用のDockerfileを追加しました。

従来は`render-build.sh`を用いてRender.comにデプロイを行なっていましたが、jemallocを導入するためにDockerでのデプロイに移行します。

