### PR TITLE
[add] アルバム検索カードでタブ機能を実装 #108

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "@radix-ui/react-progress": "^1.1.7",
         "@radix-ui/react-slider": "^1.3.5",
         "@radix-ui/react-slot": "^1.2.3",
+        "@radix-ui/react-tabs": "^1.1.12",
         "@tailwindcss/vite": "^4.1.10",
         "axios": "^1.10.0",
         "axios-case-converter": "^1.1.1",
@@ -1543,6 +1544,37 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.10.tgz",
+      "integrity": "sha512-dT9aOXUen9JSsxnMPv/0VqySQf5eDQ6LCk5Sw28kamz8wSOW2bJdlX2Bg5VUIIcV+6XlHpWTIuTPCf/UNIyq8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-slider": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-slider/-/react-slider-1.3.5.tgz",
@@ -1590,6 +1622,36 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tabs": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.12.tgz",
+      "integrity": "sha512-GTVAlRVrQrSw3cEARM0nAx73ixrWDPNZAruETn3oHCNP6SbZ/hNxdxp+u7VkIEv3/sFoLq1PfcHrl7Pnp0CDpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.10",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "@radix-ui/react-progress": "^1.1.7",
     "@radix-ui/react-slider": "^1.3.5",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-tabs": "^1.1.12",
     "@tailwindcss/vite": "^4.1.10",
     "axios": "^1.10.0",
     "axios-case-converter": "^1.1.1",

--- a/frontend/src/components/layout/CreateGridBody.jsx
+++ b/frontend/src/components/layout/CreateGridBody.jsx
@@ -1,15 +1,6 @@
 import { useState, useEffect } from 'react';
 import axios from './../../../api/lib/apiClient';
-import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from '@/components/ui/dialog';
+import { Dialog, DialogContent, DialogDescription, DialogTitle } from '@/components/ui/dialog';
 import {
   Carousel,
   CarouselContent,

--- a/frontend/src/components/ui/album_search/AlbumSearchCard.jsx
+++ b/frontend/src/components/ui/album_search/AlbumSearchCard.jsx
@@ -22,13 +22,13 @@ export default function AlbumSearchCard({
                 className="text-gray-400 data-[state=active]:bg-white data-[state=active]:text-black"
                 value="search"
               >
-                Search
+                検索
               </TabsTrigger>
               <TabsTrigger
                 className="text-gray-400 data-[state=active]:bg-white data-[state=active]:text-black"
                 value="settings"
               >
-                Settings
+                設定
               </TabsTrigger>
             </TabsList>
             <div className="h-4/5 w-full rounded-xl border border-[#2D2D2D] bg-[#1E1E1E] shadow-xl shadow-gray-900 md:mx-4 mt-4">

--- a/frontend/src/components/ui/album_search/AlbumSearchCard.jsx
+++ b/frontend/src/components/ui/album_search/AlbumSearchCard.jsx
@@ -1,5 +1,6 @@
 import SearchBar from './SearchBar';
 import SearchResult from './SearchResult';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 export default function AlbumSearchCard({
   onSearchClick,
@@ -12,20 +13,45 @@ export default function AlbumSearchCard({
   isDragging,
 }) {
   return (
-    <div className="order-2 h-screen w-full lg:order-1 lg:flex lg:w-2/5 lg:items-center">
-      <div className="h-4/5 w-full rounded-xl border border-[#2D2D2D] bg-[#1E1E1E] shadow-xl shadow-gray-900 md:mx-4">
-        <div className="h-full p-12">
-          <SearchBar onSearchClick={onSearchClick} setSearchAlbumInput={setSearchAlbumInput} />
-          <SearchResult
-            activeId={activeId}
-            isDragging={isDragging}
-            activeAlt={activeAlt}
-            activeSrc={activeSrc}
-            activeSpotifyId={activeSpotifyId}
-            albums={albums}
-          />
+    <div className="lg:w-2/5">
+      <Tabs defaultValue="search">
+        <div>
+          <div className="order-2 h-screen w-full lg:order-1">
+            <TabsList className="bg-gray-700 ml-4 mt-12">
+              <TabsTrigger
+                className="text-gray-400 data-[state=active]:bg-white data-[state=active]:text-black"
+                value="search"
+              >
+                Search
+              </TabsTrigger>
+              <TabsTrigger
+                className="text-gray-400 data-[state=active]:bg-white data-[state=active]:text-black"
+                value="settings"
+              >
+                Settings
+              </TabsTrigger>
+            </TabsList>
+            <div className="h-4/5 w-full rounded-xl border border-[#2D2D2D] bg-[#1E1E1E] shadow-xl shadow-gray-900 md:mx-4 mt-4">
+              <div className="h-full p-12">
+                <TabsContent value="search">
+                  <SearchBar
+                    onSearchClick={onSearchClick}
+                    setSearchAlbumInput={setSearchAlbumInput}
+                  />
+                  <SearchResult
+                    activeId={activeId}
+                    isDragging={isDragging}
+                    activeAlt={activeAlt}
+                    activeSrc={activeSrc}
+                    activeSpotifyId={activeSpotifyId}
+                    albums={albums}
+                  />
+                </TabsContent>
+              </div>
+            </div>
+          </div>
         </div>
-      </div>
+      </Tabs>
     </div>
   );
 }

--- a/frontend/src/components/ui/color_palette/Color.jsx
+++ b/frontend/src/components/ui/color_palette/Color.jsx
@@ -1,4 +1,4 @@
-export default function Color({ className, color, setColor }) {
+export default function Color({ color, setColor }) {
   function onColorClick() {
     setColor(color);
   }

--- a/frontend/src/components/ui/profile_cards/ProfileCard.jsx
+++ b/frontend/src/components/ui/profile_cards/ProfileCard.jsx
@@ -3,7 +3,6 @@ import React, { useState, useEffect } from 'react';
 import axios from './../../../../api/lib/apiClient';
 import Layout from '@/components/layout/Layout';
 import Header from '@/components/common/Header';
-import { Button } from '../button';
 
 export default function ProfileCard() {
   const params = useParams();

--- a/frontend/src/components/ui/tabs.jsx
+++ b/frontend/src/components/ui/tabs.jsx
@@ -1,0 +1,60 @@
+import * as React from "react"
+import * as TabsPrimitive from "@radix-ui/react-tabs"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  ...props
+}) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      className={cn("flex flex-col gap-2", className)}
+      {...props} />
+  );
+}
+
+function TabsList({
+  className,
+  ...props
+}) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      className={cn(
+        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]",
+        className
+      )}
+      {...props} />
+  );
+}
+
+function TabsTrigger({
+  className,
+  ...props
+}) {
+  return (
+    <TabsPrimitive.Trigger
+      data-slot="tabs-trigger"
+      className={cn(
+        "data-[state=active]:bg-background dark:data-[state=active]:text-foreground focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-ring dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 text-foreground dark:text-muted-foreground inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-2 py-1 text-sm font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:shadow-sm [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props} />
+  );
+}
+
+function TabsContent({
+  className,
+  ...props
+}) {
+  return (
+    <TabsPrimitive.Content
+      data-slot="tabs-content"
+      className={cn("flex-1 outline-none", className)}
+      {...props} />
+  );
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent }

--- a/frontend/src/components/ui/tabs.jsx
+++ b/frontend/src/components/ui/tabs.jsx
@@ -23,7 +23,7 @@ function TabsList({
     <TabsPrimitive.List
       data-slot="tabs-list"
       className={cn(
-        "bg-muted text-muted-foreground inline-flex h-9 w-fit items-center justify-center rounded-lg p-[3px]",
+        "bg-muted text-muted-foreground inline-flex h-11 w-fit items-center justify-center rounded-lg p-[6px]",
         className
       )}
       {...props} />


### PR DESCRIPTION
## 概要
アルバム検索カードの上に、タブを用意しました。

タブの項目はデフォルトの「検索」タブと、今後のグリッドのマスの行列の変更などを追加する予定の「設定」タブの切り替え機能を実装しました。

## 変更点
- shadcnよりTabsコンポーネントのインストール
- タブの表示

<img width="466" alt="スクリーンショット 2025-06-29 20 13 23" src="https://github.com/user-attachments/assets/1030c5aa-bb4c-4953-b606-7bdc640b4be0" />

